### PR TITLE
Add gpt options for undiscoverable partition scheme

### DIFF
--- a/edl.py
+++ b/edl.py
@@ -106,6 +106,9 @@ def main():
     parser.add_argument('-setbootablestoragedrive', metavar="<number>",
                         help='[CMD:Firehose] Set the physical partition number active for booting',default='')
     parser.add_argument('-x', metavar="<xmldata>", help='[CMD:Firehose] XML to run in firehose mode', default='')
+    parser.add_argument('-gpt-num-part-entries', metavar="<number>", type=int, help='[CMD:Firehose] Number of partitions', default=None)
+    parser.add_argument('-gpt-part-entry-size', metavar="<number>", type=int, help='[CMD:Firehose] Size of partition entry', default=None)
+    parser.add_argument('-gpt-part-entry-start-lba', metavar="<number>", type=int, help='[CMD:Firehose] Beginning of partition entries', default=None)
 
     args = parser.parse_args()
     xml = xmlparser()
@@ -189,7 +192,11 @@ def main():
         elif args.printgpt==True:
             data = fh.cmd_read_buffer(args.lun, 0, 0x4000 // 512)
             if data!='':
-                guid_gpt=gpt()
+                guid_gpt=gpt(
+                    num_part_entries=args.gpt_num_part_entries,
+                    part_entry_size=args.gpt_part_entry_size,
+                    part_entry_start_lba=args.gpt_part_entry_start_lba,
+                )
                 guid_gpt.parse(data,cfg.SECTOR_SIZE_IN_BYTES)
                 guid_gpt.print()
             else:
@@ -202,7 +209,11 @@ def main():
             partitionname=args.r[0]
             filename=args.r[1]
             data = fh.cmd_read_buffer(args.lun, 0, 0x4000 // 512,False)
-            guid_gpt = gpt()
+            guid_gpt = gpt(
+                num_part_entries=args.gpt_num_part_entries,
+                part_entry_size=args.gpt_part_entry_size,
+                part_entry_start_lba=args.gpt_part_entry_start_lba,
+            )
             guid_gpt.parse(data, cfg.SECTOR_SIZE_IN_BYTES)
 
             for partition in guid_gpt.partentries:
@@ -215,7 +226,11 @@ def main():
         elif args.rf!='':
             filename=args.rf
             data = fh.cmd_read_buffer(args.lun, 0, 0x4000 // 512,False)
-            guid_gpt = gpt()
+            guid_gpt = gpt(
+                num_part_entries=args.gpt_num_part_entries,
+                part_entry_size=args.gpt_part_entry_size,
+                part_entry_start_lba=args.gpt_part_entry_start_lba,
+            )
             guid_gpt.parse(data, cfg.SECTOR_SIZE_IN_BYTES)
             data = fh.cmd_read(args.lun, 0, guid_gpt.totalsectors, filename)
             print(f"Dumped sector 0 with sector count {str(guid_gpt.totalsectors)} as {filename}.")
@@ -300,7 +315,11 @@ def main():
                 print(f"Error: Couldn't find file: {filename}")
                 exit(0)
             data = fh.cmd_read_buffer(args.lun, 0, 0x4000 // 512,False)
-            guid_gpt = gpt()
+            guid_gpt = gpt(
+                num_part_entries=args.gpt_num_part_entries,
+                part_entry_size=args.gpt_part_entry_size,
+                part_entry_start_lba=args.gpt_part_entry_start_lba,
+            )
             guid_gpt.parse(data, cfg.SECTOR_SIZE_IN_BYTES)
 
             for partition in guid_gpt.partentries:
@@ -333,7 +352,11 @@ def main():
         elif args.e != '':
             partitionname=args.e
             data = fh.cmd_read_buffer(args.lun, 0, 0x4000 // 512,False)
-            guid_gpt = gpt()
+            guid_gpt = gpt(
+                num_part_entries=args.gpt_num_part_entries,
+                part_entry_size=args.gpt_part_entry_size,
+                part_entry_start_lba=args.gpt_part_entry_start_lba,
+            )
             guid_gpt.parse(data, cfg.SECTOR_SIZE_IN_BYTES)
 
             for partition in guid_gpt.partentries:


### PR DESCRIPTION
This MR add 3 options when the partition can't be discovered:

- -gpt-num-part-entries : Number of partitions
- -gpt-part-entry-size : Partition entry size (usually 128)
- -gpt-part-entry-start-lba : Beginning of partition (usually 1024)

```
python3.7 edl.py -loader Loaders/000940e101390002_911b8f01_FHPRG.bin -gpt-num-part-entries 12 -gpt-part-entry-size 128 -gpt-part-entry-start-lba 1024 -printgpt

Qualcomm Sahara / Firehose Client (c) B.Kerler 2018.


Using loader Loaders/000940e101390002_911b8f01_FHPRG.bin ...
Waiting for the device
Device detected :)
Mode detected: Firehose
TargetName=MSM8909
MemoryName=eMMC
Version=1

Reading from physical partition 0, sector 0, sectors 32
Progress: |██████████████████████████████████████████████████| 100.0% Complete

GPT Table:
-------------
modem:               Offset 0x0000000004000000, Length 0x0000000004000000, Flags 0x00000010, UUID 5afd4b66-cd18-713b-8e90-c0cc859a6c24, Type EFI_BASIC_DATA
sbl1:                Offset 0x0000000008000000, Length 0x0000000000080000, Flags 0x00000000, UUID 947b4b8f-83d0-70ef-aff7-f7da81855a22, Type 0xdea0ba2c
sbl1bak:             Offset 0x0000000008080000, Length 0x0000000000080000, Flags 0x00000000, UUID 06cc4d8e-2bdd-fc07-5c7e-9a3a62e938e2, Type 0xdea0ba2c
aboot:               Offset 0x0000000008100000, Length 0x0000000000100000, Flags 0x00000000, UUID 6ccd1ecc-9454-3930-0ad6-e31c7211d870, Type 0x400ffdcd
abootbak:            Offset 0x0000000008200000, Length 0x0000000000100000, Flags 0x00000000, UUID f96d66ee-819e-5aeb-1e61-aa4225274aa5, Type 0x400ffdcd
rpm:                 Offset 0x0000000008300000, Length 0x0000000000080000, Flags 0x00000000, UUID a993a252-a33e-a908-1bfe-bc721c07f3e5, Type 0x98df793
rpmbak:              Offset 0x0000000008380000, Length 0x0000000000080000, Flags 0x00000000, UUID 773804a6-2506-5aec-9bbd-7d4ecaacaed4, Type 0x98df793
tz:                  Offset 0x0000000008400000, Length 0x0000000000200000, Flags 0x00000000, UUID c9e47960-ec68-3a87-2558-ec937d386052, Type 0xa053aa7f
tzbak:               Offset 0x0000000008600000, Length 0x0000000000200000, Flags 0x00000000, UUID d698e8ab-a1f3-c061-ffb2-c299b6bab506, Type 0xa053aa7f
devcfg:              Offset 0x0000000008800000, Length 0x0000000000040000, Flags 0x00000000, UUID 24bd12ba-b035-8567-dd6c-d61cc92afb15, Type 0xf65d4b16
apdp:                Offset 0x0000000008840000, Length 0x0000000000040000, Flags 0x00000000, UUID 1e457ee0-4b58-add4-3c69-276a9043236d, Type 0xe6e98da2
pad:                 Offset 0x0000000008880000, Length 0x0000000000100000, Flags 0x00000000, UUID ee5e3dd7-2209-b55e-c7a8-53f554755d99, Type EFI_BASIC_DATA

Total disk size:0x16656dd4097e577c400, sectors:0xb32b6ea04bf2bbe2
```