### PR TITLE
EDL's rs command bug

### DIFF
--- a/edl.py
+++ b/edl.py
@@ -1396,8 +1396,8 @@ def handle_firehose(arguments, cdc, sahara, verbose):
         lun = int(arguments["--lun"])
         start = int(arguments["<start_sector>"])
         sectors = int(arguments["<sectors>"])
-        filename = arguments["<filename"]
-        data = fh.cmd_read(lun, start, sectors, filename)
+        filename = arguments["<filename>"]
+        data = fh.cmd_read_buffer(lun, start, sectors, filename)
         with open(filename, "wb") as wf:
             wf.write(data)
             print(f"Dumped sector {str(start)} with sector count {str(sectors)} as {filename}.")


### PR DESCRIPTION
Corrected bug and typo in the processing of the `read sectors' (rs) command (changed read to buffered read)