### PR TITLE
Give the expected filename when loader cannot be found

### DIFF
--- a/Library/sahara.py
+++ b/Library/sahara.py
@@ -422,7 +422,7 @@ class qualcomm_sahara():
                         #print("Couldn't find a loader for given hwid and pkhash :(")
                         #exit(0)
                 else:
-                    logger.error("Couldn't find a loader for given hwid and pkhash :(")
+                    logger.error(f"Couldn't find a loader for given hwid and pkhash ({self.hwidstr}_{self.pkhash[0:16]}_FHPRG.bin) :(")
                     exit(0)
                 with open(fname,"rb") as rf:
                     self.programmer=rf.read()


### PR DESCRIPTION
Otherwise, it quickly gets annoying to figure out the right filename
from the information the program outputs.

Now it's a quick copy/paste away, no more missing one character.