### PR TITLE
Fix generic command handler such as 'modules oemunlock'

### DIFF
--- a/Library/Modules/init.py
+++ b/Library/Modules/init.py
@@ -24,11 +24,7 @@ class modules(metaclass=LogBase):
             self.__logger.addHandler(fh)
         self.options = {}
         self.devicemodel = devicemodel
-        self.generic = None
-        try:
-            self.generic = generic(fh=self.fh, serial=self.serial, args=self.args, loglevel=self.__logger.level)
-        except Exception as e:
-            pass
+        self.generic = generic(fh=self.fh, serial=self.serial, args=self.args, logger=self.__logger)
         self.ops = None
         self.xiaomi=None
         try:


### PR DESCRIPTION
Currently generic() initialization will always throw an exception,
causing self.generic to be None and generic modules would never run.