### PR TITLE
Fix skip in firehose_client

### DIFF
--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -307,7 +307,8 @@ class firehose_client(metaclass=LogBase):
                 skipped = []
                 for skippart in skip:
                     filtered = fnmatch.filter(guid_gpt.partentries, skippart)
-                    skipped.append(filtered)
+                    if len(filtered) > 0:
+                        skipped.append(filtered[0])
                 for partitionname in guid_gpt.partentries:
                     partition = guid_gpt.partentries[partitionname]
                     if partitionname in skipped:


### PR DESCRIPTION
Skipped is an array of arrays

```python
print(*skipped", sep = ", ")

# prints
# ['super'], ['userdata']
```

My first attempt in python so probably there is a better way to fix it.

Fixes #217, #233