### PR TITLE
Fix sparse check exception

### DIFF
--- a/edlclient/Library/sparse.py
+++ b/edlclient/Library/sparse.py
@@ -43,7 +43,10 @@ class QCSparse(metaclass=LogBase):
             self.__logger.addHandler(fh)
 
     def readheader(self):
-        header = unpack("<I4H4I", self.rf.read(0x1C))
+        buf = self.rf.read(0x1C)
+        if len(buf) != 28:
+            return False
+        header = unpack("<I4H4I", buf)
         magic = header[0]
         self.major_version = header[1]
         self.minor_version = header[2]


### PR DESCRIPTION
If a program file is less than 28 bytes,
the checking for sparse header will fire exception,
Since the unpack funciton expect the input data length
to be 28 bytes.

This was accidentally reverted by commit
4d5cb463d227956fb5b3fda23274e593eaa7448b