### PR TITLE
Fixing an issues with the number of returned items of a SAHARA connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ For Oneplus 6T, enter *#801#* on dialpad, set Engineer Mode and Serial to on and
 ## Tested with
 
 - Oneplus 3T/5/6T/7T/8/8t/9/Nord CE/N10/N100 (Read-Only), BQ X, BQ X5, BQ X2, Gigaset ME Pure, ZTE MF210, ZTE MF920V, Sierra Wireless EM7455, Netgear MR1100-10EUS, Netgear MR5100
+- SIMCOM SIM8905E
 
 Published under MIT license
 Additional license limitations: No use in commercial products without prior permit.

--- a/edl
+++ b/edl
@@ -312,9 +312,9 @@ class main(metaclass=LogBase):
                         if sahara_info:
                             sahara_connnect = self.sahara.connect()
                                 if len(sahara_connnect) == 3:
-                                    mode, cmd, resp = self.sahara.connect()
+                                    mode, cmd, resp = sahara_connnect
                                 else:
-                                    mode, resp = self.sahara.connect()
+                                    mode, resp = sahara_connnect
                             if mode == "sahara":
                                 mode = self.sahara.upload_loader()
                                 if "enprg" in self.sahara.programmer.lower():

--- a/edl
+++ b/edl
@@ -310,7 +310,11 @@ class main(metaclass=LogBase):
                         self.cdc.timeout = None
                         sahara_info = self.sahara.streaminginfo()
                         if sahara_info:
-                            mode, resp = self.sahara.connect()
+                            sahara_connnect = self.sahara.connect()
+                                if len(sahara_connnect) == 3:
+                                    mode, cmd, resp = self.sahara.connect()
+                                else:
+                                    mode, resp = self.sahara.connect()
                             if mode == "sahara":
                                 mode = self.sahara.upload_loader()
                                 if "enprg" in self.sahara.programmer.lower():


### PR DESCRIPTION
Quick fix, maybe to improve...

Got an issue trying to communicate with the tool after a glitching attack:
```
$ edl rl dumps --skip=userdata --genxml
Qualcomm Sahara / Firehose Client V3.60 (c) B.Kerler 2018-2022.
main - Trying with no loader given ...
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 2.1
main - Mode detected: sahara
Device is in streaming mode, uploading loader
sahara - Device serial : 0x19******
sahara - Protocol version: 2.1
Traceback (most recent call last):
  File "/usr/local/bin/edl", line 4, in <module>
    __import__('pkg_resources').run_script('edlclient==3.60', 'edl')
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 667, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 1463, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python3.8/dist-packages/edlclient-3.60-py3.8.egg/EGG-INFO/scripts/edl", line 380, in <module>
    base.run()
  File "/usr/local/lib/python3.8/dist-packages/edlclient-3.60-py3.8.egg/EGG-INFO/scripts/edl", line 313, in run
    mode, resp = self.sahara.connect()
ValueError: too many values to unpack (expected 2)
```

So I'm not sure how the code actually handled streaming mode but looks to work like a charm if the state is stable with EDL:
```
Qualcomm Sahara / Firehose Client V3.60 (c) B.Kerler 2018-2022.
main - Trying with no loader given ...
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 2.1
main - Mode detected: sahara
sahara - 
------------------------
HWID:              0x00********** (MSM_ID:0x00****************,OEM_ID:0x0000,MODEL_ID:0x0000)
CPU detected:      "MSM8909"
PK_HASH:           0xcc3*************************************
Serial:            0x19*******************

sahara - Possibly unfused device detected, so any loader should be fine...
```

