### PR TITLE
udev: add match for ZTE 19d2:0076 QDL USB ID

### DIFF
--- a/Drivers/51-edl.rules
+++ b/Drivers/51-edl.rules
@@ -13,3 +13,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1004", ATTRS{idProduct}=="61a1", MODE="0666
 
 # Sierra Wireless
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1199", ATTRS{idProduct}=="9071", MODE="0666", GROUP="plugdev"
+
+# ZTE
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="19d2", ATTRS{idProduct}=="0076", MODE="0666", GROUP="plugdev"


### PR DESCRIPTION
Add match for ZTE modems diagnostic port with USB ID 19d2:0076