### PR TITLE
firehos: fix MaxPayloadSizeToTargetInBytes handling

### DIFF
--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -889,7 +889,7 @@ class firehose(metaclass=LogBase):
                     else:
                         self.error("Error on EDL Authentification")
                         return False
-                elif "MaxPayloadSizeToTargetInBytes" in line:
+                elif "MaxPayloadSizeToTargetInBytes" in rsp.data:
                     try:
                         self.cfg.MemoryName = rsp.data["MemoryName"]
                         self.cfg.MaxPayloadSizeToTargetInBytes = int(rsp.data["MaxPayloadSizeToTargetInBytes"])


### PR DESCRIPTION
Before this change [MSM8916-based unbranded chinese USB LTE modem](https://hackaday.com/2022/08/03/hackable-20-modem-combines-lte-and-pi-zero-w2-power/) would fail to configure when running `edl` for the second time in a single boot (after loader has already been launched) without showing any specific error message/warning.

```
main - Mode detected: firehose
main - Trying to connect to firehose loader ...
firehose_client
firehose_client - [LIB]: No --memory option set, we assume "eMMC" as default ..., if it fails, try using "--memory" with "UFS","NAND" or "spinor" instead !
DeviceClass
DeviceClass - [LIB]: ['  File "/home/informatic/Projects/edl/edl", line 391, in <module>\n    base.run()\n', '  File "/home/informatic/Projects/edl/edl", line 385, in run\n    if fh.connect(sahara):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose_client.py", line 109, in connect\n    if self.firehose.configure(0):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 853, in configure\n    rsp = self.xmlsend(connectcmd)\n']
DeviceClass
DeviceClass - [LIB]: TX:<?xml version="1.0" encoding="UTF-8" ?><data><configure MemoryName="eMMC" Verbose="0" AlwaysValidate="0" MaxDigestTableSizeInBytes="2048" MaxPayloadSizeToTargetInBytes="1048576" ZLPAwareHost="1" SkipStorageInit="0" SkipWrite="0"/></data>
DeviceClass
DeviceClass - [LIB]: read:0x6e
DeviceClass
DeviceClass - [LIB]: ['  File "/home/informatic/Projects/edl/edl", line 391, in <module>\n    base.run()\n', '  File "/home/informatic/Projects/edl/edl", line 385, in run\n    if fh.connect(sahara):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose_client.py", line 109, in connect\n    if self.firehose.configure(0):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 853, in configure\n    rsp = self.xmlsend(connectcmd)\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 248, in xmlsend\n    tmp = self.cdc.read(timeout=None)\n']
DeviceClass
DeviceClass - [LIB]: RX:<?xml version="1.0" encoding="UTF-8" ?><data><log value="Host's payload to target size is too large" /></data>
DeviceClass
DeviceClass - [LIB]: read:0x63
DeviceClass
DeviceClass - [LIB]: ['  File "/home/informatic/Projects/edl/edl", line 391, in <module>\n    base.run()\n', '  File "/home/informatic/Projects/edl/edl", line 385, in run\n    if fh.connect(sahara):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose_client.py", line 109, in connect\n    if self.firehose.configure(0):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 853, in configure\n    rsp = self.xmlsend(connectcmd)\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 248, in xmlsend\n    tmp = self.cdc.read(timeout=None)\n']
DeviceClass
DeviceClass - [LIB]: RX:<?xml version="1.0" encoding="UTF-8" ?><data><log value="logbuf@0x0801CAB0 fh@0x08019918" /></data>
DeviceClass
DeviceClass - [LIB]: read:0x129
DeviceClass
DeviceClass - [LIB]: ['  File "/home/informatic/Projects/edl/edl", line 391, in <module>\n    base.run()\n', '  File "/home/informatic/Projects/edl/edl", line 385, in run\n    if fh.connect(sahara):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose_client.py", line 109, in connect\n    if self.firehose.configure(0):\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 853, in configure\n    rsp = self.xmlsend(connectcmd)\n', '  File "/home/informatic/Projects/edl/edlclient/Library/firehose.py", line 248, in xmlsend\n    tmp = self.cdc.read(timeout=None)\n']
DeviceClass
DeviceClass - [LIB]: RX:<?xml version="1.0" encoding="UTF-8" ?><data><response value="NAK" MinVersionSupported="1" MemoryName="eMMC" MaxPayloadSizeFromTargetInBytes="4096" MaxPayloadSizeToTargetInBytes="16384" MaxPayloadSizeToTargetInBytesSupported="16384" MaxXMLSizeInBytes="4096" Version="1" TargetName="8916" /></data>
```

Not sure if this is a perfect fix since I have no idea if this was a typo, or intended behaviour on some specific devices. Probably matching on `Host's payload to target size is too large` in `line` could work too, or we could keep existing `line` matching behaviour as an alternative.

Probably adding *any* warning/error message whenever `self.firehose.configure(0)` fails in `edlclient/Library/firehose_client.py` could ease up debugging for someone next time. :) Right now this just exits out as seen in logs above.