### PR TITLE
Fix exception when processing nop cmd

### DIFF
--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -339,7 +339,7 @@ class firehose(metaclass=LogBase):
     def cmd_nop(self):
         data = "<?xml version=\"1.0\" ?><data><nop /></data>"
         resp = self.xmlsend(data, True)
-        self.debug(resp.hex())
+        self.debug(resp.data.hex())
         info = b""
         tmp = None
         while tmp != b"":


### PR DESCRIPTION
edlclient.Library.firehose.response class doesn't have a hex method. This results into an exception when running cmd_nop function. Assuming we want to print the hex of data here, use resp.data.hex() instead of resp.hex()