### PR TITLE
Because Sony uses a different ID's, add that - this will be a learnin…

### DIFF
--- a/Drivers/51-edl.rules
+++ b/Drivers/51-edl.rules
@@ -2,6 +2,9 @@
 # Qualcomm EDL
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="05c6", ATTRS{idProduct}=="9008", MODE="0666", GROUP="plugdev"
 
+# Sony EDL
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fce", ATTRS{idProduct}=="9dde", MODE="0666", GROUP="plugdev"
+
 # Qualcomm Memory Debug
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="05c6", ATTRS{idProduct}=="9006", MODE="0666", GROUP="plugdev"
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ User: user, Password:user (based on Ubuntu 22.04 LTS)
 
 ## Installation
 
+#### Grab files and install
+```
+git clone https://github.com/bkerler/edl
+cd edl
+git submodule update --init --recursive
+pip3 install -r requirements.txt
+```
+
 ### Linux (Debian/Ubuntu/Mint/etc): 
 ```bash
 # Debian/Ubuntu/Mint/etc
@@ -37,8 +45,8 @@ cd edl
 git submodule update --init --recursive
 sudo cp Drivers/51-edl.rules /etc/udev/rules.d
 sudo cp Drivers/50-android.rules /etc/udev/rules.d
-python setup.py build
-sudo python setup.py install
+python3 setup.py build
+sudo python3 setup.py install
 ```
 
 ### macOS:
@@ -48,8 +56,8 @@ brew install libusb git
 git clone https://github.com/bkerler/edl.git
 cd edl
 git submodule update --init --recursive
-python setup.py build
-sudo python setup.py install
+python3 setup.py build
+sudo python3 setup.py install
 ```
 
 ### Windows:
@@ -58,13 +66,6 @@ sudo python setup.py install
 - If you install python from microsoft store, "python setup.py install" will fail, but that step isn't required.
 - WIN+R ```cmd```
 
-#### Grab files and install
-```
-git clone https://github.com/bkerler/edl
-cd edl
-git submodule update --init --recursive
-pip3 install -r requirements.txt
-```
 
 #### Get latest UsbDk 64-Bit
 - Install normal QC 9008 Serial Port driver (or use default Windows COM Port one, make sure no exclamation is seen)

--- a/edlclient/Config/usb_ids.py
+++ b/edlclient/Config/usb_ids.py
@@ -1,5 +1,6 @@
 default_ids = [
     [0x05c6, 0x9008, -1],
+    [0x0fce, 0x9dde, -1],
     [0x05c6, 0x900e, -1],
     [0x05c6, 0x9025, -1],
     [0x1199, 0x9062, -1],
@@ -15,6 +16,7 @@ default_diag_vid_pid = [
     [0x1199, 0x9091, -1],  # Sierra Wireless
     [0x0846, 0x68e2,  2],  # Netgear
     [0x05C6, 0x9008, -1],  # QC EDL
+    [0x0fce, 0x9dde, -1],  # SONY EDL
     [0x05C6, 0x676C, 0],   # QC Handset
     [0x05c6, 0x901d, 0],   # QC Android "setprop sys.usb.config diag,adb"
     [0x19d2, 0x0016, -1],  # ZTE Diag


### PR DESCRIPTION
…g experience
```
Device is a Sony Z3 D6603
So I'm not even sure this is correct yet, say does 0x9dde translate to 0x900e? 
I'm hoping we can figure this out, I'm still trying to get comfortable with the tools. 
PK_HASH and SERIAL is removed as i seem to remember the PK_HASH being the cryto key. 

i get the following output  : 
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 2, Version supported: 1
main - Mode detected: sahara
sahara -
------------------------
HWID:              0x007b40e100010004 (MSM_ID:0x007b40e1,OEM_ID:0x0001,MODEL_ID:0x0004)
CPU detected:      "MSM8974AB"
PK_HASH:           0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
Serial:            0xffffffff

sahara - Protocol version: 2, Version supported: 1
sahara - Uploading loader /media/thread/500gb-qc/brick/edl/Loaders/qualcomm/factory/msm8974ab/007b40e100310262_cc3153a80293939b_fhprg.bin ...
sahara - 32-Bit mode detected.
sahara - Firehose mode detected, uploading...
Traceback (most recent call last):
  File "/media/thread/500gb-qc/brick/edl/./edl", line 391, in <module>
    base.run()
  File "/media/thread/500gb-qc/brick/edl/./edl", line 370, in run
    if "load_" in mode:
       ^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable

```