### PR TITLE
fix attribut error in oemunlock

### DIFF
--- a/edlclient/Library/Modules/generic.py
+++ b/edlclient/Library/Modules/generic.py
@@ -27,7 +27,7 @@ class generic(metaclass=LogBase):
         if res[0]:
             lun = res[1]
             rpartition = res[2]
-            if rpartition.sectors <= (0x8000//self.cfg.SECTOR_SIZE_IN_BYTES):
+            if rpartition.sectors <= (0x8000//self.fh.cfg.SECTOR_SIZE_IN_BYTES):
                 offsettopatch = 0x7FFF
                 sector, offset = self.fh.calc_offset(rpartition.sector, offsettopatch)
             else:


### PR DESCRIPTION
---

**Description:**

This pull request addresses an issue related to the attribute `cfg.SECTOR_SIZE_IN_BYTES` in the `generic` class (#463). The issue stems from the fact that `cfg.SECTOR_SIZE_IN_BYTES` is not a direct attribute of the generic class but belongs to the `firehose` class.

**Testing:**

I was only able to test with my own device therefore it might be necessary to do further testing (as to insure previously functioning case are still working).

---