### PR TITLE
fix sparse get size()

### DIFF
--- a/edlclient/Library/sparse.py
+++ b/edlclient/Library/sparse.py
@@ -81,7 +81,7 @@ class QCSparse(metaclass=LogBase):
         chunk_sz = header[2]
         total_sz = header[3]
         data_sz = total_sz - 12
-        self.rf.seek(self.rf.tell + data_sz)
+        self.rf.seek(self.rf.tell() + data_sz)
 
         if chunk_type == 0xCAC1:
             if data_sz != (chunk_sz * self.blk_sz):

--- a/edlclient/Library/sparse.py
+++ b/edlclient/Library/sparse.py
@@ -81,20 +81,21 @@ class QCSparse(metaclass=LogBase):
         chunk_sz = header[2]
         total_sz = header[3]
         data_sz = total_sz - 12
+        self.rf.seek(self.rf.tell + data_sz)
+
         if chunk_type == 0xCAC1:
             if data_sz != (chunk_sz * self.blk_sz):
                 self.error(
                     "Raw chunk input size (%u) does not match output size (%u)" % (data_sz, chunk_sz * self.blk_sz))
                 return -1
             else:
-                self.rf.seek(self.rf.tell() + chunk_sz * self.blk_sz)
                 return chunk_sz * self.blk_sz
         elif chunk_type == 0xCAC2:
             if data_sz != 4:
                 self.error("Fill chunk should have 4 bytes of fill, but this has %u" % data_sz)
                 return -1
             else:
-                return chunk_sz * self.blk_sz // 4
+                return chunk_sz * self.blk_sz
         elif chunk_type == 0xCAC3:
             return chunk_sz * self.blk_sz
         elif chunk_type == 0xCAC4:
@@ -102,7 +103,6 @@ class QCSparse(metaclass=LogBase):
                 self.error("CRC32 chunk should have 4 bytes of CRC, but this has %u" % data_sz)
                 return -1
             else:
-                self.rf.seek(self.rf.tell() + 4)
                 return 0
         else:
             self.debug("Unknown chunk type 0x%04X" % chunk_type)

--- a/edlclient/Library/sparse.py
+++ b/edlclient/Library/sparse.py
@@ -81,7 +81,6 @@ class QCSparse(metaclass=LogBase):
         chunk_sz = header[2]
         total_sz = header[3]
         data_sz = total_sz - 12
-        self.rf.seek(self.rf.tell() + data_sz)
 
         if chunk_type == 0xCAC1:
             if data_sz != (chunk_sz * self.blk_sz):
@@ -89,12 +88,14 @@ class QCSparse(metaclass=LogBase):
                     "Raw chunk input size (%u) does not match output size (%u)" % (data_sz, chunk_sz * self.blk_sz))
                 return -1
             else:
+                self.rf.seek(self.rf.tell() + data_sz)
                 return chunk_sz * self.blk_sz
         elif chunk_type == 0xCAC2:
             if data_sz != 4:
                 self.error("Fill chunk should have 4 bytes of fill, but this has %u" % data_sz)
                 return -1
             else:
+                self.rf.seek(self.rf.tell() + data_sz)
                 return chunk_sz * self.blk_sz
         elif chunk_type == 0xCAC3:
             return chunk_sz * self.blk_sz
@@ -103,6 +104,7 @@ class QCSparse(metaclass=LogBase):
                 self.error("CRC32 chunk should have 4 bytes of CRC, but this has %u" % data_sz)
                 return -1
             else:
+                self.rf.seek(self.rf.tell() + data_sz)
                 return 0
         else:
             self.debug("Unknown chunk type 0x%04X" % chunk_type)


### PR DESCRIPTION
I'm assuming you are trying to get the actual size of the full image. then chunktype `fill` should be of size chunk_sz * blk_sz. The same for chunktype `skip` as these just try to fill in or write null to these chunks.