### PR TITLE
Fix setactiveslot by sending multiple patch chunks

### DIFF
--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -1316,8 +1316,8 @@ class firehose(metaclass=LogBase):
                                 size_each_patch, True)
                 if i < header_size:
                     header_subset = int(unpack("<I", header[offset:offset+size_each_patch])[0])
-                    self.cmd_patch(lun, headeroffset, \
-                                offset, \
+                    self.cmd_patch( lun, headeroffset, \
+                                    offset, \
                                     header_subset, \
                                     size_each_patch, True)
                 offset += size_each_patch

--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -1303,19 +1303,24 @@ class firehose(metaclass=LogBase):
             return None
 
     def cmd_setactiveslot(self, slot: str):
-        def cmd_patch_multiple(lun, start_sector_patch, byte_offset_patch, headeroffset, pdata, header):
-            offset = 0 
+        def cmd_patch_multiple(lun, start_sector_patch, byte_offset_patch, headeroffset, pdata,  header):
+            offset = 0
             header_size = len(header)
-            pdata_size = len(pdata)
-            write_size = pdata_size # with assumption pdata_size > header_size
-            patch_subset_size = 4
-            for i in range(0, write_size, patch_subset_size):
-                pdata_subset = int(unpack("<I", pdata[offset:offset+patch_subset_size])[0])
-                self.cmd_patch(lun, start_sector_patch, byte_offset_patch, pdata_subset, patch_subset_size, True)
+            size_each_patch = 4
+            write_size = len(pdata)
+            for i in range(0, write_size, size_each_patch):
+                pdata_subset = int(unpack("<I", pdata[offset:offset+size_each_patch])[0])
+                self.cmd_patch( lun, start_sector_patch, \
+                                byte_offset_patch + offset, \
+                                pdata_subset, \
+                                size_each_patch, True)
                 if i < header_size:
-                    header_subset = int(unpack("<I", header[offset:offset+patch_subset_size])[0])
-                    self.cmd_patch(lun, headeroffset, 0, header_subset, patch_subset_size, True)
-                offset += patch_subset_size
+                    header_subset = int(unpack("<I", header[offset:offset+size_each_patch])[0])
+                    self.cmd_patch(lun, headeroffset, \
+                                offset, \
+                                    header_subset, \
+                                    size_each_patch, True)
+                offset += size_each_patch
             return True
 
         if slot.lower() not in ["a", "b"]:

--- a/edlclient/Library/gpt.py
+++ b/edlclient/Library/gpt.py
@@ -224,7 +224,7 @@ class gpt(metaclass=LogBase):
             self.name = sh.string(72)
 
         def create(self):
-            val = pack("16s16sQQQ72s", self.type, self.unique, self.first_lba, self.last_lba, self.flags, self.name)
+            val = pack("<16s16sQQQ72s", self.type, self.unique, self.first_lba, self.last_lba, self.flags, self.name)
             return val
 
     class efi_type(Enum):
@@ -498,7 +498,7 @@ class gpt(metaclass=LogBase):
                             if active:
                                 flags |= AB_PARTITION_ATTR_SLOT_ACTIVE << (AB_FLAG_OFFSET*8)
                             else:
-                                flags |= AB_PARTITION_ATTR_UNBOOTABLE << (AB_FLAG_OFFSET*8)
+                                flags &= AB_PARTITION_ATTR_UNBOOTABLE << (AB_FLAG_OFFSET*8)
                             partentry.flags = flags
                             pdata = partentry.create()
                             return pdata, partition.entryoffset


### PR DESCRIPTION
this fixes: https://github.com/bkerler/edl/issues/511, https://github.com/bkerler/edl/issues/402 https://github.com/bkerler/edl/issues/472

Confirm changing to slot b:
```
system_a:            Offset 0x0000000002208000, Length 0x00000002e5510000, Flags 0x0000000000000000, UUID 8d40cb7a-57b6-f435-e760-33794bfc7669, Type 0x97d7b011, Active False
system_b:            Offset 0x00000002e7718000, Length 0x00000002e5510000, Flags 0x0004000000000000, UUID cdfddd29-279b-a4c1-39b0-11bf88149800, Type 0x77036cd4, Active True
```

Also, I changed it to setting every partition with ending  `_a` or `_b` be set active or non active accordingly. the previous implementation just change one partition only and then return

Also,  for setting unactive slot, I'm fairly new to this but we set the flags like this 
```flags &= ~(AB_PARTITION_ATTR_SLOT_ACTIVE << (AB_FLAG_OFFSET*8))```, or like that in the PR