### PR TITLE
Ensure integrity of gpt header partitions

### DIFF
--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -1411,7 +1411,7 @@ class firehose(metaclass=LogBase):
                 return True
             return False
 
-        def check_fix_gpt_hdr(guid_gpt, backup_guid_gpt, gpt_data, backup_gpt_data):
+        def ensure_gpt_hdr_consistency(guid_gpt, backup_guid_gpt, gpt_data, backup_gpt_data):
             headeroffset = guid_gpt.sectorsize
             prim_corrupted, backup_corrupted = False, False
 
@@ -1480,11 +1480,11 @@ class firehose(metaclass=LogBase):
                                 backup_gpt_data_b, backup_guid_gpt_b = self.get_gpt(lun_b, 0, 0 , 0, guid_gpt_b.header.backup_lba)
 
                             if not check_gpt_hdr:
-                                sts, gpt_data_a, backup_gpt_data_a = check_fix_gpt_hdr(guid_gpt_a, backup_guid_gpt_a, gpt_data_a, backup_gpt_data_a)
+                                sts, gpt_data_a, backup_gpt_data_a = ensure_gpt_hdr_consistency(guid_gpt_a, backup_guid_gpt_a, gpt_data_a, backup_gpt_data_a)
                                 if not sts:
                                     return False
                                 if lun_a != lun_b:
-                                    sts, gpt_data_b, backup_gpt_data_b = check_fix_gpt_hdr(guid_gpt_b, backup_guid_gpt_b, gpt_data_b, backup_gpt_data_b)
+                                    sts, gpt_data_b, backup_gpt_data_b = ensure_gpt_hdr_consistency(guid_gpt_b, backup_guid_gpt_b, gpt_data_b, backup_gpt_data_b)
                                     if not sts:
                                         return False
                                 check_gpt_hdr = True

--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -231,10 +231,7 @@ class firehose(metaclass=LogBase):
                 break
             else:
                 if partitionname in guid_gpt.partentries:
-                    if send_full:
-                        return [True, lun, data, guid_gpt]
-                    else:
-                        return [True, lun, guid_gpt.partentries[partitionname]]
+                    return [True, lun, data, guid_gpt] if send_full else [True, lun, guid_gpt.partentries[partitionname]]
             for part in guid_gpt.partentries:
                 fpartitions[lunname].append(part)
         return [False, fpartitions]
@@ -756,13 +753,14 @@ class firehose(metaclass=LogBase):
         resp = rsp["value"] == "ACK"
         return response(resp=resp, data=resData, error=rsp[2])  # Do not remove, needed for oneplus
 
-    def get_gpt(self, lun, gpt_num_part_entries, gpt_part_entry_size, gpt_part_entry_start_lba):
+    # TODO: this should be able to get backup gpt as well
+    def get_gpt(self, lun, gpt_num_part_entries, gpt_part_entry_size, gpt_part_entry_start_lba, start_sector=0, primary=True):
         try:
-            resp = self.cmd_read_buffer(lun, 0, 2, False)
+            resp = self.cmd_read_buffer(lun, 0, 1, False)
         except Exception as err:
             self.debug(str(err))
             self.skipresponse = True
-            resp = self.cmd_read_buffer(lun, 0, 2, False)
+            resp = self.cmd_read_buffer(lun, 0, 1, False)
 
         if not resp.resp:
             for line in resp.error:
@@ -770,6 +768,7 @@ class firehose(metaclass=LogBase):
             return None, None
         data = resp.data
         magic = unpack("<I", data[0:4])[0]
+        data = self.cmd_read_buffer(lun, start_sector, 1, False).data
         if magic == 0x844bdcd1:
             self.info("Nand storage detected.")
             self.info("Scanning for partition table ...")
@@ -777,7 +776,7 @@ class firehose(metaclass=LogBase):
             if self.nandpart.partitiontblsector is None:
                 sector = 0x280
                 progbar.show_progress(prefix="Scanning", pos=sector, total=1024, display=True)
-                resp = self.cmd_read_buffer(0, sector, 1, False)
+                resp = self.cmd_read_buffer(start_sector, sector, 1, False)
                 if resp.resp:
                     if resp.data[0:8] in [b"\xac\x9f\x56\xfe\x7a\x12\x7f\xcd", b"\xAA\x73\xEE\x55\xDB\xBD\x5E\xE3"]:
                         progbar.show_progress(prefix="Scanning", pos=1024, total=1024, display=True)
@@ -787,7 +786,7 @@ class firehose(metaclass=LogBase):
                     self.error("Error on reading partition table data")
                     return None, None
             if self.nandpart.partitiontblsector is not None:
-                resp = self.cmd_read_buffer(0, self.nandpart.partitiontblsector + 1, 2, False)
+                resp = self.cmd_read_buffer(start_sector, self.nandpart.partitiontblsector + 1, 2, False)
                 if resp.resp:
                     if self.nandpart.parse(resp.data):
                         return resp.data, self.nandpart
@@ -804,7 +803,8 @@ class firehose(metaclass=LogBase):
                 loglevel=self.__logger.level
             )
             try:
-                header = guid_gpt.parseheader(data, self.cfg.SECTOR_SIZE_IN_BYTES)
+                offset = self.cfg.SECTOR_SIZE_IN_BYTES if primary else 0
+                header = guid_gpt.parseheader(data, offset)
                 if header.signature == b"EFI PART":
                     gptsize = (header.part_entry_start_lba * self.cfg.SECTOR_SIZE_IN_BYTES) + (
                             header.num_part_entries * header.part_entry_size)
@@ -812,15 +812,30 @@ class firehose(metaclass=LogBase):
                     if gptsize % self.cfg.SECTOR_SIZE_IN_BYTES != 0:
                         sectors += 1
                     if sectors == 0:
+                        self.error("sectors == 0")
                         return None, None
                     if sectors > 64:
                         sectors = 64
-                    data = self.cmd_read_buffer(lun, 0, sectors, False)
-                    if data == b"":
-                        return None, None
-                    guid_gpt.parse(data.data, self.cfg.SECTOR_SIZE_IN_BYTES)
-                    return data.data, guid_gpt
+                    if primary:
+                        data = self.cmd_read_buffer(lun, start_sector, sectors, False)
+                        if data == b"":
+                            self.error("data is empty")
+                            return None, None
+                        guid_gpt.parse(data.data, self.cfg.SECTOR_SIZE_IN_BYTES)
+                        return data.data, guid_gpt
+                    else:
+                        num_part_sectors = (header.num_part_entries * header.part_entry_size)//self.cfg.SECTOR_SIZE_IN_BYTES
+                        if num_part_sectors % self.cfg.SECTOR_SIZE_IN_BYTES != 0:
+                            num_part_sectors += 1
+                        self.warning(f"{num_part_sectors}")
+                        part_table = self.cmd_read_buffer(lun, header.part_entry_start_lba, num_part_sectors, False)
+                        #self.warning("got here")
+                        #self.warning(f"{data}")
+                        parse_data =  (b'0' * self.cfg.SECTOR_SIZE_IN_BYTES) + data + part_table.data
+                        guid_gpt.parse(parse_data, self.cfg.SECTOR_SIZE_IN_BYTES)
+                        return parse_data, guid_gpt
                 else:
+                    self.error(" in error efipart")
                     return None, None
             except Exception as err:
                 self.debug(str(err))
@@ -884,7 +899,7 @@ class firehose(metaclass=LogBase):
         '''
         "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><data><response value=\"ACK\" MinVersionSupported=\"1\"" \
         "MemoryName=\"eMMC\" MaxPayloadSizeFromTargetInBytes=\"4096\" MaxPayloadSizeToTargetInBytes=\"1048576\" " \
-        "MaxPayloadSizeToTargetInBytesSupported=\"1048576\" MaxXMLSizeInBytes=\"4096\" Version=\"1\" 
+        "MaxPayloadSizeToTargetInBytesSupported=\"1048576\" MaxXMLSizeInBytes=\"4096\" Version=\"1\"
         TargetName=\"8953\" />" \
         "</data>"
         '''
@@ -1312,20 +1327,54 @@ class firehose(metaclass=LogBase):
             self.warning("GetStorageInfo command isn't supported.")
             return None
 
-    def cmd_setactiveslot(self, slot: str):
-        def cmd_patch_multiple(lun, start_sector, byte_offset, patch_data):
-            offset = 0
-            size_each_patch = 4
-            write_size = len(patch_data)
-            for i in range(0, write_size, size_each_patch):
-                pdata_subset = int(unpack("<I", patch_data[offset:offset+size_each_patch])[0])
-                self.cmd_patch( lun, start_sector, \
-                                byte_offset + offset, \
-                                pdata_subset, \
-                                size_each_patch, True)
-                offset += size_each_patch
-            return True
+    # 1. check for integrity of the primary header and integrity of backup header
+    #   Yes?: update primary header + update backup header
+    #   No? : which one is corrupted? --> update the corrupted one with the other one
+    # 2. how to fix corruption
+    #  -> fix header (patch)
+    #  -> fix partition table (write)
 
+    def check_gpt_integrity(self, gptData, guid_gpt):
+        primary_header = guid_gpt.header
+
+    def cmd_patch_multiple(self, lun, start_sector, byte_offset, patch_data):
+        offset = 0
+        size_each_patch = 4
+        write_size = len(patch_data)
+        for i in range(0, write_size, size_each_patch):
+            pdata_subset = int(unpack("<I", patch_data[offset:offset+size_each_patch])[0])
+            self.cmd_patch( lun, start_sector, \
+                            byte_offset + offset, \
+                            pdata_subset, \
+                            size_each_patch, True)
+            offset += size_each_patch
+        return True
+
+    def update_gpt_info(self, new_hdr_a, new_hdr_b,
+                        pdata_a, pdata_b,
+                        lun_a, lun_b,
+                        start_sector_hdr_a, start_sector_hdr_b,
+                        start_sector_patch_a, start_sector_patch_b,
+                        byte_offset_patch_a, byte_offset_patch_b
+                        ):
+
+        self.cmd_patch_multiple(lun_a, start_sector_patch_a, byte_offset_patch_a, pdata_a)
+
+        # header will be updated in partitionname_b if in same lun
+        if lun_a != lun_b:
+            #headeroffset_a = guid_gpt_a.header.current_lba * guid_gpt_a.sectorsize
+            #start_sector_hdr_a = guid_gpt_a.header.current_lba
+            #pheader_a = new_gpt_data_a[headeroffset_a : headeroffset_a+guid_gpt_a.header.header_size]
+            self.cmd_patch_multiple(lun_a, start_sector_hdr_a, 0, new_hdr_a)
+
+        self.cmd_patch_multiple(lun_b, start_sector_patch_b, byte_offset_patch_b, pdata_b)
+        #headeroffset_b = guid_gpt_b.header.current_lba * guid_gpt_b.sectorsize
+        #start_sector_hdr_b = guid_gpt_b.header.current_lba
+        #pheader_b = new_gpt_data_b[headeroffset_b : headeroffset_b+guid_gpt_b.header.header_size]
+        self.cmd_patch_multiple(lun_b, start_sector_hdr_b, 0, new_hdr_b)
+
+
+    def cmd_setactiveslot(self, slot: str):
         # flags: 0x3a for inactive and 0x6f for active boot partition
         def set_flags(flags, active, is_boot):
             new_flags = flags
@@ -1344,12 +1393,12 @@ class firehose(metaclass=LogBase):
                 else:
                     new_flags &= ~(AB_PARTITION_ATTR_SLOT_ACTIVE << (AB_FLAG_OFFSET*8))
             return new_flags
-        
-        def patch_helper(header_data_a, header_data_b, guid_gpt, partition_a, partition_b, slot_a_status, slot_b_status, is_boot):
+
+        def patch_helper(gpt_data_a, gpt_data_b, guid_gpt, partition_a, partition_b, slot_a_status, slot_b_status, is_boot):
             part_entry_size = guid_gpt.header.part_entry_size
 
-            rf_a = BytesIO(header_data_a)
-            rf_b = BytesIO(header_data_b)
+            rf_a = BytesIO(gpt_data_a)
+            rf_b = BytesIO(gpt_data_b)
 
             rf_a.seek(partition_a.entryoffset)
             rf_b.seek(partition_b.entryoffset)
@@ -1377,11 +1426,11 @@ class firehose(metaclass=LogBase):
             slot_a_status = False
         slot_b_status = not slot_a_status
         fpartitions = {}
-        try: 
+        try:
             for lun_a in self.luns:
                 lunname = "Lun" + str(lun_a)
                 fpartitions[lunname] = []
-                header_data_a, guid_gpt_a = self.get_gpt(lun_a, int(0), int(0), int(0))
+                gpt_data_a, guid_gpt_a = self.get_gpt(lun_a, int(0), int(0), int(0))
                 if guid_gpt_a is None:
                     break
                 else:
@@ -1391,14 +1440,15 @@ class firehose(metaclass=LogBase):
                             partitionname_b = partitionname_a[:-1] + "b"
                             if partitionname_b in guid_gpt_a.partentries:
                                 lun_b = lun_a
-                                header_data_b = header_data_a
+                                gpt_data_b = gpt_data_a
                                 guid_gpt_b = guid_gpt_a
                             else:
                                 resp = self.detect_partition(arguments=None, partitionname=partitionname_b, send_full=True)
                                 if not resp[0]:
+                                    self.warning("in here")
                                     self.error(f"Cannot find partition {partitionname_b}")
                                     return False
-                                _, lun_b, header_data_b, guid_gpt_b = resp
+                                _, lun_b, gpt_data_b, guid_gpt_b = resp
 
                             part_a = guid_gpt_a.partentries[partitionname_a]
                             part_b = guid_gpt_b.partentries[partitionname_b]
@@ -1406,44 +1456,85 @@ class firehose(metaclass=LogBase):
                             if partitionname_a == "boot_a":
                                 is_boot = True
                             pdata_a, poffset_a, pdata_b, poffset_b = patch_helper(
-                                header_data_a, header_data_b,
+                                gpt_data_a, gpt_data_b,
                                 guid_gpt_a, part_a, part_b,
                                 slot_a_status, slot_b_status,
                                 is_boot
                             )
 
-                            header_data_a[poffset_a : poffset_a+len(pdata_a)] = pdata_a
-                            new_header_a = guid_gpt_a.fix_gpt_crc(header_data_a)
-                            header_data_b[poffset_b:poffset_b + len(pdata_b)] = pdata_b
-                            new_header_b = guid_gpt_b.fix_gpt_crc(header_data_b)
+                            if gpt_data_a and gpt_data_b:
+                                gpt_data_a[poffset_a : poffset_a+len(pdata_a)] = pdata_a
+                                new_gpt_data_a = guid_gpt_a.fix_gpt_crc(gpt_data_a)
+                                gpt_data_b[poffset_b:poffset_b + len(pdata_b)] = pdata_b
+                                new_gpt_data_b = guid_gpt_b.fix_gpt_crc(gpt_data_b)
 
-                            if new_header_a is not None:
-                                start_sector_patch_a = poffset_a // self.cfg.SECTOR_SIZE_IN_BYTES
-                                byte_offset_patch_a = poffset_a % self.cfg.SECTOR_SIZE_IN_BYTES
-                                cmd_patch_multiple(lun_a, start_sector_patch_a, byte_offset_patch_a, pdata_a)
+                                prim_start_sector_patch_a = poffset_a // self.cfg.SECTOR_SIZE_IN_BYTES
+                                prim_byte_offset_patch_a = poffset_a % self.cfg.SECTOR_SIZE_IN_BYTES
+                                prim_start_sector_hdr_a = guid_gpt_a.header.current_lba
 
-                                # header will be updated in partitionname_b if in same lun
-                                if lun_a != lun_b:
-                                    headeroffset_a = guid_gpt_a.header.current_lba * guid_gpt_a.sectorsize
-                                    start_sector_hdr_a = guid_gpt_a.header.current_lba
-                                    pheader_a = new_header_a[headeroffset_a : headeroffset_a+guid_gpt_a.header.header_size]
-                                    cmd_patch_multiple(lun_a, start_sector_hdr_a, 0, pheader_a)
-                            
-                            if new_header_b is not None:
-                                start_sector_patch_b = poffset_b // self.cfg.SECTOR_SIZE_IN_BYTES
-                                byte_offset_patch_b = poffset_b % self.cfg.SECTOR_SIZE_IN_BYTES
-                                cmd_patch_multiple(lun_b, start_sector_patch_b, byte_offset_patch_b, pdata_b)
+                                prim_start_sector_patch_b = poffset_b // self.cfg.SECTOR_SIZE_IN_BYTES
+                                prim_byte_offset_patch_b = poffset_b % self.cfg.SECTOR_SIZE_IN_BYTES
+                                prim_start_sector_hdr_b = guid_gpt_b.header.current_lba
 
-                                headeroffset_b = guid_gpt_b.header.current_lba * guid_gpt_b.sectorsize
-                                start_sector_hdr_b = guid_gpt_b.header.current_lba
-                                pheader_b = new_header_b[headeroffset_b : headeroffset_b+guid_gpt_b.header.header_size]
-                                cmd_patch_multiple(lun_b, start_sector_hdr_b, 0, pheader_b)
+                                headeroffset_a = prim_start_sector_hdr_a * guid_gpt_a.sectorsize
+                                new_hdr_a = new_gpt_data_a[headeroffset_a : headeroffset_a+guid_gpt_a.header.header_size]
+                                headeroffset_b = prim_start_sector_hdr_b * guid_gpt_b.sectorsize
+                                new_hdr_b = new_gpt_data_b[headeroffset_b : headeroffset_b+guid_gpt_b.header.header_size]
+
+                                #self.update_gpt_info(new_hdr_a, new_hdr_b,
+                                #                     pdata_a, pdata_b,
+                                #                     lun_a, lun_b,
+                                #                     prim_start_sector_hdr_a, prim_start_sector_hdr_b,
+                                #                     prim_start_sector_patch_a, prim_start_sector_patch_b,
+                                #                     prim_byte_offset_patch_a, prim_byte_offset_patch_b)
+
+                                resp_a = self.cmd_read_buffer(lun_a, guid_gpt_a.header.backup_lba, 1, False)
+                                if not (resp_a.resp):
+                                    self.error("Error in trying to retrieve backup gpt headers")
+                                    return False
+                                backup_hdr_a = gpt.gpt_header(resp_a.data)
+                                sectors = (backup_hdr_a.num_part_entries * backup_hdr_a.part_entry_size) // self.cfg.SECTOR_SIZE_IN_BYTES
+                                part_table_a = self.cmd_read_buffer(lun_a, backup_hdr_a.part_entry_start_lba, sectors, False)
+                                if lun_a == lun_b:
+                                    backup_hdr_b = backup_hdr_a
+                                    part_table_b = part_table_a
+                                else:
+                                    resp_b = self.cmd_read_buffer(lun_b, guid_gpt_b.header.backup_lba, 1, False)
+                                    backup_hdr_b = gpt.gpt_header(resp_b.data)
+                                    part_table_b = self.cmd_read_buffer(lun_b, backup_hdr_b.part_entry_start_lba, sectors, False)
+
+
+                                #print(f"signature: {backup_hdr_a.signature}")
+                                #print(f"revision: {backup_hdr_a.revision}")
+                                #print(f"header size: {backup_hdr_a.header_size}")
+                                #print(f"crc32: {backup_hdr_a.crc32}")
+                                #print(f"reserved: {backup_hdr_a.reserved}")
+                                #print(f"current_lba: {backup_hdr_a.current_lba}")
+                                #print(f"backup_lba: {backup_hdr_a.backup_lba}")
+                                #print(f"first_usable_lba: {backup_hdr_a.first_usable_lba}")
+                                #print(f"last_usable_lba: {backup_hdr_a.last_usable_lba}")
+                                #print(f"disk_guid: {backup_hdr_a.disk_guid}")
+                                #print(f"part_entry_stzrt_lba: {backup_hdr_a.part_entry_start_lba}")
+                                #print(f"num_part_entries: {backup_hdr_a.num_part_entries}")
+                                #print(f"part_entry_size: {backup_hdr_a.part_entry_size}")
+                                #print(f"crc32_part_entries: {backup_hdr_a.crc32_part_entries}")
+
+
+                                #back_gpt_data_a, backup_guid_gpt_a = self.get_gpt(lun_a, 0, 0 , 0, start_sector=guid_gpt_a.header.backup_lba, primary=False)
+                                #if (backup_guid_gpt_a is None):
+                                #    self.error("error in backup")
+                                #    return False
+
+                                return True
+
+                                #self self.update_gpt_info()
+
         except Exception as err:
             self.error(str(err))
             return False
         return True
 
-    
+
 
     def cmd_test(self, cmd):
         token = "1234"
@@ -1562,12 +1653,12 @@ class firehose(metaclass=LogBase):
         data = f"<?xml version=\"1.0\" ?><data><peek address64=\"{address}\" " + \
                f"size_in_bytes=\"{SizeInBytes}\" /></data>\n"
         '''
-            <?xml version="1.0" encoding="UTF-8" ?><data><log value="Using address 00100000" /></data> 
-            <?xml version="1.0" encoding="UTF-8" ?><data><log value="0x22 0x00 0x00 0xEA 0x70 0x00 0x00 0xEA 0x74 0x00 
-            0x00 0xEA 0x78 0x00 0x00 0xEA 0x7C 0x00 0x00 0xEA 0x80 0x00 0x00 0xEA 0x84 0x00 0x00 0xEA 0x88 0x00 0x00 
-            0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 
-            0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 
-            0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 
+            <?xml version="1.0" encoding="UTF-8" ?><data><log value="Using address 00100000" /></data>
+            <?xml version="1.0" encoding="UTF-8" ?><data><log value="0x22 0x00 0x00 0xEA 0x70 0x00 0x00 0xEA 0x74 0x00
+            0x00 0xEA 0x78 0x00 0x00 0xEA 0x7C 0x00 0x00 0xEA 0x80 0x00 0x00 0xEA 0x84 0x00 0x00 0xEA 0x88 0x00 0x00
+            0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA
+            0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE
+            0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF
             0xFF 0xEA 0xFE 0xFF 0xFF 0xEA 0xFE 0xFF " /></data>
             '''
         try:

--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -207,13 +207,15 @@ class firehose_client(metaclass=LogBase):
                                                        int(options["--gpt-part-entry-start-lba"]))
                 if guid_gpt is None:
                     break
-                with open(sfilename, "wb") as write_handle:
-                    write_handle.write(data)
+                #with open(sfilename, "wb") as write_handle:
+                #    #write_handle.write(data)
+                #    pass
 
                 self.printer(f"Dumped GPT from Lun {str(lun)} to {sfilename}")
                 sfilename = os.path.join(directory, f"gpt_backup{str(lun)}.bin")
-                with open(sfilename, "wb") as write_handle:
-                    write_handle.write(data[self.firehose.cfg.SECTOR_SIZE_IN_BYTES * 2:])
+                #with open(sfilename, "wb") as write_handle:
+                #    #write_handle.write(data[self.firehose.cfg.SECTOR_SIZE_IN_BYTES * 2:])
+                #    pass
                 self.printer(f"Dumped Backup GPT from Lun {str(lun)} to {sfilename}")
                 if genxml:
                     guid_gpt.generate_rawprogram(lun, self.firehose.cfg.SECTOR_SIZE_IN_BYTES, directory)

--- a/edlclient/Library/gpt.py
+++ b/edlclient/Library/gpt.py
@@ -351,7 +351,6 @@ class gpt(metaclass=LogBase):
 
 
     def parse(self, gptdata, sectorsize=512):
-        self.warning("got here")
         self.header = self.gpt_header(gptdata[sectorsize:sectorsize + 0x5C])
         self.sectorsize = sectorsize
         if self.header.signature != b"EFI PART":
@@ -362,7 +361,7 @@ class gpt(metaclass=LogBase):
         if self.part_entry_start_lba != 0:
             start = self.part_entry_start_lba
         else:
-            start = self.header.part_entry_start_lba * sectorsize
+            start = 2 * sectorsize # mbr + header + part_table
 
         entrysize = self.header.part_entry_size
         self.partentries = {}
@@ -395,7 +394,7 @@ class gpt(metaclass=LogBase):
             pa.sector = partentry.first_lba
             pa.sectors = partentry.last_lba - partentry.first_lba + 1
             pa.flags = partentry.flags
-            pa.entryoffset = start + (idx * entrysize)
+            pa.entryoffset = (self.header.part_entry_start_lba * sectorsize) + (idx * entrysize)
             type = int(unpack("<I", partentry.type[0:0x4])[0])
             try:
                 pa.type = self.efi_type(type).name

--- a/edlclient/Library/gpt.py
+++ b/edlclient/Library/gpt.py
@@ -351,6 +351,7 @@ class gpt(metaclass=LogBase):
 
 
     def parse(self, gptdata, sectorsize=512):
+        self.warning("got here")
         self.header = self.gpt_header(gptdata[sectorsize:sectorsize + 0x5C])
         self.sectorsize = sectorsize
         if self.header.signature != b"EFI PART":

--- a/edlclient/Library/gpt.py
+++ b/edlclient/Library/gpt.py
@@ -498,9 +498,9 @@ class gpt(metaclass=LogBase):
 
     def fix_gpt_crc(self, data):
         partentry_size = self.header.num_part_entries * self.header.part_entry_size
-        partentry_offset = self.header.part_entry_start_lba * self.sectorsize
+        partentry_offset = 2 * self.sectorsize
         partdata = data[partentry_offset:partentry_offset + partentry_size]
-        headeroffset = self.header.current_lba * self.sectorsize
+        headeroffset = self.sectorsize
         headerdata = bytearray(data[headeroffset:headeroffset + self.header.header_size])
         headerdata[0x58:0x58 + 4] = pack("<I", crc32(partdata))
         headerdata[0x10:0x10 + 4] = pack("<I", 0)

--- a/erase.sh
+++ b/erase.sh
@@ -1,0 +1,9 @@
+FLASH_SLOT="b"
+./edl e aop_$FLASH_SLOT --memory=ufs
+./edl e devcfg_$FLASH_SLOT --memory=ufs
+./edl e xbl_$FLASH_SLOT --memory=ufs
+./edl e xbl_config_$FLASH_SLOT --memory=ufs
+./edl e abl_$FLASH_SLOT --memory=ufs
+./edl e boot_$FLASH_SLOT --memory=ufs
+./edl e system_$FLASH_SLOT --memory=ufs
+./edl reset

--- a/erase.sh
+++ b/erase.sh
@@ -1,9 +1,0 @@
-FLASH_SLOT="b"
-./edl e aop_$FLASH_SLOT --memory=ufs
-./edl e devcfg_$FLASH_SLOT --memory=ufs
-./edl e xbl_$FLASH_SLOT --memory=ufs
-./edl e xbl_config_$FLASH_SLOT --memory=ufs
-./edl e abl_$FLASH_SLOT --memory=ufs
-./edl e boot_$FLASH_SLOT --memory=ufs
-./edl e system_$FLASH_SLOT --memory=ufs
-./edl reset


### PR DESCRIPTION
@bkerler, this is an enhancement to the `setactiveslot` command, it ensures the integrity of the primary gpt header by checking the header crc32 and partition table crc32. if the primary gpt header is corrupted or doesn't match its crc32 value with that of backup gpt header, it would recover from the backup gpt header.

I have also made it possible to update the backup gpt header as well, but I think it is best practice to make it get updated by the xbl partition during boot up process. I'm not sure this mechanism is available for other qualcomm chipset, but definitely for sdm845