### PR TITLE
Improve `getactiveslot` command

### DIFF
--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -658,7 +658,7 @@ class firehose_client(metaclass=LogBase):
                 lun = res[1]
                 prim_guid_gpt = res[3]
                 _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0, prim_guid_gpt.header.backup_lba)
-                partition = backup_guid_gpt.partentries["boot_a"]
+                partition = backup_guid_gpt.partentries["boot_b"]
                 active = ((partition.flags >> (AB_FLAG_OFFSET*8))&0xFF) & AB_PARTITION_ATTR_SLOT_ACTIVE == AB_PARTITION_ATTR_SLOT_ACTIVE
                 if active:
                     self.printer("Current active slot: b")

--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -643,19 +643,21 @@ class firehose_client(metaclass=LogBase):
             else:
                 return self.firehose.cmd_setbootablestoragedrive(int(options["<lun>"]))
         elif cmd == "getactiveslot":
-            res = self.firehose.detect_partition(options, "boot_a")
+            res = self.firehose.detect_partition(options, "boot_a", send_full=True)
             if res[0]:
                 lun = res[1]
-                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0)
+                prim_guid_gpt = res[3]
+                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0, prim_guid_gpt.header.backup_lba)
                 partition = backup_guid_gpt.partentries["boot_a"]
                 active = ((partition.flags >> (AB_FLAG_OFFSET*8))&0xFF) & AB_PARTITION_ATTR_SLOT_ACTIVE == AB_PARTITION_ATTR_SLOT_ACTIVE
                 if active:
                     self.printer("Current active slot: a")
                     return True
-            res = self.firehose.detect_partition(options, "boot_b")
+            res = self.firehose.detect_partition(options, "boot_b", send_full=True)
             if res[0]:
                 lun = res[1]
-                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0)
+                prim_guid_gpt = res[3]
+                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0, prim_guid_gpt.header.backup_lba)
                 partition = backup_guid_gpt.partentries["boot_a"]
                 active = ((partition.flags >> (AB_FLAG_OFFSET*8))&0xFF) & AB_PARTITION_ATTR_SLOT_ACTIVE == AB_PARTITION_ATTR_SLOT_ACTIVE
                 if active:

--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -646,7 +646,8 @@ class firehose_client(metaclass=LogBase):
             res = self.firehose.detect_partition(options, "boot_a")
             if res[0]:
                 lun = res[1]
-                partition = res[2]
+                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0)
+                partition = backup_guid_gpt.partentries["boot_a"]
                 active = ((partition.flags >> (AB_FLAG_OFFSET*8))&0xFF) & AB_PARTITION_ATTR_SLOT_ACTIVE == AB_PARTITION_ATTR_SLOT_ACTIVE
                 if active:
                     self.printer("Current active slot: a")
@@ -654,7 +655,8 @@ class firehose_client(metaclass=LogBase):
             res = self.firehose.detect_partition(options, "boot_b")
             if res[0]:
                 lun = res[1]
-                partition = res[2]
+                _, backup_guid_gpt = self.firehose.get_gpt(lun, 0, 0, 0)
+                partition = backup_guid_gpt.partentries["boot_a"]
                 active = ((partition.flags >> (AB_FLAG_OFFSET*8))&0xFF) & AB_PARTITION_ATTR_SLOT_ACTIVE == AB_PARTITION_ATTR_SLOT_ACTIVE
                 if active:
                     self.printer("Current active slot: b")


### PR DESCRIPTION
@bkerler The backup gpt header is more reliable to get the activeslot assuming the procedure of setting the activeslot is as follow: 

`setactiveslot()` (update on primary gpt header only) --> no crash --> turn on --> xbl updates backup gpt header

if it crashes during patching then the primary gpt header is corrupted, so it would be better to get the active slot from the backup gpt header

