### PR TITLE
fix erase to return when erase success

### DIFF
--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -847,7 +847,7 @@ class firehose_client(metaclass=LogBase):
                             f"Erased {partitionname} starting at sector {str(partition.sector)} " +
                             f"with sector count {str(partition.sectors)}.")
                         return True
-            self.printer(
+            self.error(
                 f"Couldn't erase partition {partitionname}. Either wrong memorytype given or no gpt partition.")
             return False
         elif cmd == "ep":

--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -831,7 +831,6 @@ class firehose_client(metaclass=LogBase):
             luns = self.getluns(options)
             partitionname = options["<partitionname>"]
             partitions = partitionname.split(",")
-            error = False
             for lun in luns:
                 data, guid_gpt = self.firehose.get_gpt(lun, int(options["--gpt-num-part-entries"]),
                                                        int(options["--gpt-part-entry-size"]),
@@ -847,14 +846,10 @@ class firehose_client(metaclass=LogBase):
                         self.printer(
                             f"Erased {partitionname} starting at sector {str(partition.sector)} " +
                             f"with sector count {str(partition.sectors)}.")
-                    else:
-                        self.printer(
-                            f"Couldn't erase partition {partitionname}. Either wrong memorytype given or no gpt partition.")
-                        error = True
-                        continue
-            if error:
-                return False
-            return True
+                        return True
+            self.printer(
+                f"Couldn't erase partition {partitionname}. Either wrong memorytype given or no gpt partition.")
+            return False
         elif cmd == "ep":
             if not self.check_param(["<partitionname>", "<sectors>"]):
                 return False

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+./edl w xbl_a /home/bongb/web_qdl/agnos_images/xbl.img
+./edl reset

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,2 +1,0 @@
-./edl w xbl_a /home/bongb/web_qdl/agnos_images/xbl.img
-./edl reset


### PR DESCRIPTION
@bkerler. I'm not sure whether previous implementation is correct or not since it implies that there are multiple luns that have a specific `partitionname`. This PR returns immediately when we found our desired partition, and fails when we don't find our partition parsing through all the luns. Since I only tested on my SDM845, I'm not sure if other devices are different. If the previous implementation is correct, feel free to close this PR