### PR TITLE
Less verbose after first run()

### DIFF
--- a/edl
+++ b/edl
@@ -343,6 +343,9 @@ class main(metaclass=LogBase):
                             print("Error on sahara handshake, resetting.")
                             self.sahara.cmd_reset()
                             sys.exit(1)
+        else:
+            if self.__logger.level != logging.DEBUG:
+                self.__logger.setLevel(logging.ERROR)
         if mode == "error":
             print("Connection detected, quiting.")
             sys.exit(1)

--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -1361,7 +1361,7 @@ class firehose(metaclass=LogBase):
             write_size = len(patch_data)
             for i in range(0, write_size, size_each_patch):
                 pdata_subset = int(unpack(unpack_fmt, patch_data[offset:offset+size_each_patch])[0])
-                self.cmd_patch( lun, start_sector, byte_offset + offset, pdata_subset, size_each_patch, True)
+                self.cmd_patch( lun, start_sector, byte_offset + offset, pdata_subset, size_each_patch, False)
                 offset += size_each_patch
             return True
 

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,3 +1,0 @@
-./edl w xbl_a /home/bongb/agnos/xbl.img
-./edl w xbl_a /home/bongb/agnos/xbl.img
-./edl reset

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,3 @@
+./edl w xbl_a /home/bongb/agnos/xbl.img
+./edl w xbl_a /home/bongb/agnos/xbl.img
+./edl reset


### PR DESCRIPTION
@bkerler. After connecting to `Sahara` or the first run, `edl` becomes less verbose and would only output ERROR messages.