### PR TITLE
Support hex digits in OnePlus projid

### DIFF
--- a/edlclient/Library/Modules/oneplus.py
+++ b/edlclient/Library/Modules/oneplus.py
@@ -149,7 +149,7 @@ class oneplus(metaclass=LogBase):
                 data = self.fh.cmd_read_buffer(lun, rpartition.sector, 1, False)
                 value = data.data[24:24 + 5]
                 try:
-                    test = int(value.decode('utf-8'))
+                    test = int(value.decode('utf-8'), 16)
                     self.info("Oneplus protection with prjid %d detected" % test)
                     projid = value.decode('utf-8')
                 except:


### PR DESCRIPTION
Most of the `deviceconfig` keys have only 0-9 digits, however the format is actually hex, as evidenced by a handful of entries, for example:

https://github.com/bkerler/edl/blob/8573eba1b576305fec3a068393283143ffc34342/edlclient/Library/Modules/oneplus.py#L115-L116

This change should fix the immediate error reported in: https://github.com/bkerler/edl/issues/237

(Even with this fix I'm having trouble getting writes to work for other reasons on the OnePlus 9 Pro, but I figure it make sense to fix the issues one at a time.)