### PR TITLE
SoC dumping fixes

### DIFF
--- a/edl.bat
+++ b/edl.bat
@@ -1,0 +1,3 @@
+@echo off
+title EDLClient
+python "%~dp0edl" %*

--- a/edlclient/Config/qualcomm_config.py
+++ b/edlclient/Config/qualcomm_config.py
@@ -59,8 +59,6 @@ msmids = {
     0x9780E1: "IPQ4018",
     0x9790E1: "IPQ4019",
     0x0160E1: "QCA4020",
-    0x9680E1: "APQ8009", # Snapdragon 212
-    0x7060E1: "APQ8016",
     0x8100E1: "APQ806x",
     0x9D00E1: "APQ8076",
     0x08A0E1: "APQ807x",
@@ -70,11 +68,13 @@ msmids = {
     0x9410E1: "APQ8094",  # Snapdragon 810
     0x0940E1: "MSM8905",
     0x9600E1: "MSM8909",  # SnapDragon 210
-    0x0510E1: "MSM8909W",
-    0x0520E1: "APQ8009W",  # wear3100
+    0x9680E1: "APQ8009",
+    0x0510E1: "MSM8909w",
+    0x0520E1: "APQ8009w",
     0x0960E1: "SDX24",  # 0x60020100 soc_hw_version, 0x8fff7000 dbgpolicy 32Bit, 0x8FCFD000 sec.elf 64Bit
     0x0970E1: "SDX24M",  # 0x60020100 soc_hw_version, 0x8fff7000 dbgpolicy 32Bit, 0x8FCFD000 sec.elf 64Bit
     0x7050E1: "MSM8916",  # SnapDragon 410
+    0x7060E1: "APQ8016",
     0x0560E1: "MSM8917",  # Snapdragon 425
     0x0860E1: "MSM8920",
     0x91B0E1: "MSM8929",  # SnapDragon 415
@@ -418,14 +418,15 @@ infotbl = {
 
     "IPQ4018": secgen[4],
     "IPQ4019": secgen[4],
-    "APQ8009": secgen[4],
-    "APQ8016": secgen[4],
     "APQ8036": secgen[4],
     "APQ8039": secgen[4],
     "MSM8905": secgen[4],
     "MSM8909": secgen[4],
-    "MSM8909W": secgen[4],
+    "APQ8009": secgen[4],
+    "MSM8909w": secgen[4],
+    "APQ8009w": secgen[4],
     "MSM8916": secgen[4],
+    "APQ8016": secgen[4],
     "MSM8929": secgen[4],
     "MSM8939": secgen[4],
     "MSM8952": secgen[4],
@@ -592,14 +593,15 @@ class memory_type:
 
         "IPQ4018": emmc,
         "IPQ4019": emmc,
-        "APQ8009": emmc,
-        "APQ8016": emmc,
         "APQ8036": emmc,
         "APQ8039": emmc,
         "MSM8905": emmc,
         "MSM8909": emmc,
-        "MSM8909W": emmc,
+        "APQ8009": emmc,
+        "MSM8909w": emmc,
+        "APQ8009w": emmc,
         "MSM8916": emmc,
+        "APQ8016": emmc,
         "MSM8929": emmc,
         "MSM8939": emmc,
         "MSM8952": emmc,
@@ -726,8 +728,6 @@ secureboottbl = {
     "QCA6390": 0x01e20010,
     "IPQ4018": 0x00058098,
     "IPQ4019": 0x00058098,
-    "APQ8009": 0x00058098,
-    "APQ8016": 0x00058098,
     "APQ8036": 0x00058098,
     "APQ8039": 0x00058098,
     "APQ8037": 0x000a01d0,
@@ -743,8 +743,11 @@ secureboottbl = {
     "MSM8610": 0xFC4B83E8,
     "MSM8905": 0x00058098,
     "MSM8909": 0x00058098,
-    "MSM8909W": 0x00058098,
+    "APQ8009": 0x00058098,
+    "MSM8909w": 0x00058098,
+    "APQ8009w": 0x00058098,
     "MSM8916": 0x00058098,
+    "APQ8016": 0x00058098,
     "MSM8917": 0x000A01D0,
     "MSM8920": 0x000A01D0,
     "MSM8929": 0x00058098,


### PR DESCRIPTION
I already explained everything about this PR in the commit messages, please read those and if anyone has questions, I will still be happy to answer them for you.

I tried to fix the footer command as well but IDK if it needs UFS, couldn't get it working on my mobvoi-catfish:

```

Qualcomm Sahara / Firehose Client V3.62 (c) B.Kerler 2018-2024.
main - Using loader /Loaders/qualcomm/model_generic/msm8909w/0000000000000000_b01193679ab2eac7_fhprg_peek.bin ...
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 2, Version supported: 1
main - Mode detected: sahara
sahara - 
Version 0x2
------------------------
HWID:              0x000520e100000000 (MSM_ID:0x000520e1,OEM_ID:0x0000,MODEL_ID:0x0000)
CPU detected:      "APQ8009w"
PK_HASH:           0xcc3153a80293939b90d02d3bf8b23e0292e452fef662c74998421adad42a380f
Serial:            0x16e0f376

sahara - Protocol version: 2, Version supported: 1
sahara - Uploading loader /Loaders/qualcomm/model_generic/msm8909w/0000000000000000_b01193679ab2eac7_fhprg_peek.bin ...
sahara - 32-Bit mode detected.
sahara - Firehose mode detected, uploading...
sahara - Loader successfully uploaded.
main - Trying to connect to firehose loader ...
firehose_client
firehose_client - [LIB]: No --memory option set, we assume "eMMC" as default ..., if it fails, try using "--memory" with "UFS","NAND" or "spinor" instead !
firehose
firehose - [LIB]: !DEBUG! rsp.data: 'bytearray(b'<?xml version="1.0" encoding="UTF-8" ?><data><log value="logbuf@0x080548D0 fh@0x08051738" /></data>')'
firehose - TargetName=MSM8909w
firehose - MemoryName=eMMC
firehose - Version=1
firehose - Trying to read first storage sector...
firehose - Running configure...
firehose_client - Supported functions:
-----------------
Traceback (most recent call last):
  File "/home/ce1cecl/edl/./edl", line 393, in <module>
    base.run()
  File "/home/ce1cecl/edl/./edl", line 385, in run
    if not fh.handle_firehose(cmd, options):
  File "/home/ce1cecl/edl/edlclient/Library/firehose_client.py", line 490, in handle_firehose
    if partition.name != pname:
AttributeError: 'str' object has no attribute 'name'
root@LenovoLegionT5:/home/ce1cecl/edl# 

```

Also fastpwn.exe has a missing dll, so it doesn't work, but there is no instructions on how it was modified or made.

But this PR fixes other issues I had with this tool that I can think of. 