### PR TITLE
Fixed calling an attribute on a string.

### DIFF
--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -734,9 +734,9 @@ class firehose_client(metaclass=LogBase):
                         for lun in fpartitions:
                             for partition in fpartitions[lun]:
                                 if self.cfg.MemoryName == "emmc":
-                                    self.error("\t" + partition.name)
+                                    self.error("\t" + partition)
                                 else:
-                                    self.error(lun + ":\t" + partition.name)
+                                    self.error(lun + ":\t" + partition)
             if bad:
                 return False
             else:


### PR DESCRIPTION
Ran into a small bug preventing error messages from printing, as the partition variable is a string variable and not a data type with the attribute name.
