### PR TITLE
`wl`: fix indentation in gpt check and be flexible

### DIFF
--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -784,9 +784,12 @@ class firehose_client(metaclass=LogBase):
                             return False
                         self.printer(f"Writing {filename} to partition {str(partition.name)}.")
                         self.firehose.cmd_program(lun, partition.sector, filename)
-                else:
-                    self.printer("Couldn't write partition. Either wrong memorytype given or no gpt partition.")
-                    return False
+                    else:
+                        if partname[0:3] == "gpt" or partname[-3:] == "xml":
+                            self.printer(f"Can't find a partition named {partname} in the gpt, but continuing anyway.")
+                            continue
+                        self.error(f"Couldn't write partition {partname}. Either wrong memorytype given or no gpt partition.")
+                        return False
             return True
         elif cmd == "ws":
             if not self.check_param(["<start_sector>"]):


### PR DESCRIPTION
There was a trivial indentation bug, but also `rl` tends to create files like gpt_main0.bin and rawprogram0.xml, which we shouldn't try to write with `wl`.

Probably fixes #278.