### PR TITLE
Provide info about permission issue

### DIFF
--- a/edlclient/Library/Connection/usblib.py
+++ b/edlclient/Library/Connection/usblib.py
@@ -244,6 +244,8 @@ class usb_class(DeviceClass):
                 self.device.set_configuration()
                 self.configuration = self.device.get_active_configuration()
             if e.errno == 13:
+                self.error("Permission denied accessing {:04x}:{:04x}.".format(self.vid,self.pid))
+                self.info("Potential fix (update udev rules): sudo echo 'SUBSYSTEM==\"usb\",ATTRS{{idVendor}}==\"{:04x}\",ATTRS{{idProduct}}==\"{:04x}\",MODE=\"0666\"' >> /etc/udev/rules.d/99-edl.rules".format(self.vid,self.pid))
                 self.backend = usb.backend.libusb0.get_backend()
                 self.device = usb.core.find(idVendor=self.vid, idProduct=self.pid, backend=self.backend)
         if self.configuration is None:


### PR DESCRIPTION
- **Add hint for permission denying.**
- **Add `logs` directory.**
- **Provide potential fix to permission issues.**

In linux, when current user have no access to `/dev/ttyUSBx`, only a
`Couldn't get device configuration.` logged, even if using `--debugmode`.

This PR provide more error log and potential fix (update udev rules).
