### PR TITLE
Add SDX75 keys

### DIFF
--- a/edlclient/Tools/sierrakeygen.py
+++ b/edlclient/Tools/sierrakeygen.py
@@ -128,6 +128,8 @@ prodtable = {
     "MDM9x15A": dict(openlock=24, openmep=23, opencnd=24, clen=8, init=[7, 3, 0, 1, 5],  # AC779S
                      run="resultbuffer[i]=self.SierraAlgo(challenge[i], 4, 2, 1, 0, 3, 2, 0, 0)"),
     "SDX65": dict(openlock=25, openmep=21, opencnd=26, clen=8, init=[7, 3, 0, 1, 5],  # MR6400 new fw
+                  run="resultbuffer[i]=self.SierraAlgo(challenge[i], 4, 2, 1, 0, 3, 2, 0, 0)"),
+    "SDX75": dict(openlock=28, openmep=27, opencnd=28, clen=8, init=[7, 3, 0, 1, 5],  # MR7400-1A1NAS_23115898_NTGX75_10.03.22.01_00_ATT_02.11
                   run="resultbuffer[i]=self.SierraAlgo(challenge[i], 4, 2, 1, 0, 3, 2, 0, 0)")
 }
 
@@ -151,7 +153,8 @@ infotable = {
     "MDM9x40": ["MR1100", "AC815s", "AC785s", "AC797S"],
     "MDM9x50": ["EM7565", "EM7565-9", "EM7511", "EM7411"],
     "SDX55": ["MR5100", "MR5200", "ac797-100eus", "MR6400"],
-    "SDX65": ["MR6400", "MR6500", "MR6110", "MR6150", "MR6450", "MR6550"]
+    "SDX65": ["MR6400", "MR6500", "MR6110", "MR6150", "MR6450", "MR6550"],
+    "SDX75": ["MR7400"]
 }
 
 # 0 MC8775_H2.0.8.19 !OPENLOCK, !OPENCND .. MC8765V,MC8765,MC8755V,MC8775,MC8775V,MC8775,AC850,
@@ -208,7 +211,11 @@ keytable = bytearray([0xF0, 0x14, 0x55, 0x0D, 0x5E, 0xDA, 0x92, 0xB3, 0xA7, 0x6C
                       # 25 NTGX65 Openlock Key, NTGX65_10.04.13.03
                       0xF2, 0x4A, 0x9A, 0x2C, 0xDA, 0x3D, 0xA5, 0xE2, 0x6B, 0x56, 0x9A, 0x45, 0x29, 0x25, 0x77, 0x9A,
                       # 26 NTGX65 Openadm Key, NTGX65_10.04.13.03
-                      0x46, 0x30, 0x33, 0x43, 0x44, 0x36, 0x42, 0x34, 0x41, 0x32, 0x31, 0x32, 0x30, 0x35, 0x39, 0x37
+                      0x46, 0x30, 0x33, 0x43, 0x44, 0x36, 0x42, 0x34, 0x41, 0x32, 0x31, 0x32, 0x30, 0x35, 0x39, 0x37,
+                      # 27 NTGX75 Openmep Key, NTGX75_10.03.22.01
+                      0xC8, 0x6D, 0x41, 0x84, 0x8F, 0xA0, 0x73, 0x4B, 0x4B, 0x93, 0x6A, 0x08, 0x41, 0xEA, 0x56, 0x97,
+                      # 28 NTGX75 Openlock Key, NTGX75_10.03.22.01
+                      0xEE, 0xB8, 0x48, 0x7E, 0xB1, 0xA2, 0xA9, 0x18, 0x8E, 0x7B, 0x44, 0xCE, 0xE6, 0x24, 0xCB, 0xF7
                       ])
 
 


### PR DESCRIPTION
Netgear has released a family of new M7 Pro devices (such as the MR7400-1A1NAS). I add new generator keys extracted from the firmware MR7400-1A1NAS_23115898_NTGX75_10.03.22.01_00_ATT_02.11. The key for !OPENLOCK and !OPENCND is tested on a real device. The key for !OPENMEP could not be verified because the command is blocked on AT&T devices