### PR TITLE
edl/run: Handle missing version in conninfo data

### DIFF
--- a/edl
+++ b/edl
@@ -289,9 +289,9 @@ class main(metaclass=LogBase):
         self.cdc.timeout = 1500
         conninfo = self.doconnect(loop)
         mode = conninfo["mode"]
-        if conninfo.get("data"):
+        try:
             version = conninfo.get("data").version
-        else:
+        except AttributeError:
             version = 2
         if mode == "sahara":
             cmd = conninfo["cmd"]


### PR DESCRIPTION
The 'conninfo' dictionary returned by the connection process might not always contain a 'data' key with a 'version' attribute.

Instead of directly accessing '.version', the code now uses a try-except block to catch the AttributeError. If the 'version' attribute is missing, it defaults to version 2, ensuring the subsequent logic can proceed without error.