### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Qualcomm Sahara / Firehose Attack Client / Diag Tools
-(c) B. Kerler 2018-2024
+(c) B. Kerler 2018-2025
 Licensed under GPLv3 license.
 
 # Be aware that if you use anything from this repository in any (including) compiled form, you need to opensource your code as well !
@@ -42,15 +42,24 @@ sudo dnf install adb fastboot python3-devel python3-pip xz-devel git
 # Arch/Manjaro/etc
 sudo pacman -S android-tools python python-pip git xz
 sudo pacman -R modemmanager
+# Gentoo (run as root!)
+emerge -aq dev-util/android-tools dev-vcs/git dev-python/pip
 
+# For systemd distros
 sudo systemctl stop ModemManager
 sudo systemctl disable ModemManager
-sudo apt purge ModemManager
+# For OpenRC distros (run as root!)
+rc-update del modemmanager default boot sysinit
+rc-service modemmanager stop
 
-
-git clone https://github.com/bkerler/edl.git
+git clone https://github.com/bkerler/edl.git # do NOT use --recurse-submodules
 cd edl
 git submodule update --init --recursive
+
+# Autoinstall (run as root!)
+./autoinstall.sh
+
+# Manual install
 chmod +x ./install-linux-edl-drivers.sh
 bash ./install-linux-edl-drivers.sh
 python3 setup.py build

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+
+PATH_SCRIPT=$(dirname "${0}")
+
+[ "$(id -u)" != 0 ] && { printf "\nYou must run this script as root!\n" && exit 1; }
+
+if [ "$(uname -s)" = "Linux" ]; then
+	if ! "${PATH_SCRIPT}/install-linux-edl-drivers.sh"; then
+		printf "\nFailed to install the needed drivers!\n" && exit 1
+	fi
+fi
+
+if ! pip3 install -r "${PATH_SCRIPT}/requirements.txt" --break-system-packages; then
+	printf "\nFailed to install the dependencies!\n" && exit 1
+fi
+
+# The CFLAGS below is needed if your GCC version is >= 14
+if ! CFLAGS="-Wno-int-conversion" pip3 install -U "${PATH_SCRIPT}" --break-system-packages; then
+	printf "\nFailed to install this program!\n" && exit 1
+fi
+
+printf "\nInstallation complete! Now rebuild your initramfs and reboot\n"

--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -1677,8 +1677,12 @@ class firehose(metaclass=LogBase):
         if info:
             print_progress(0, 100, prefix='Progress:', suffix='Complete', bar_length=50)
         while True:
-            tmp = self.cdc.read(timeout=None)
-            if b'<response' in tmp or b"ERROR" in tmp:
+            received_data = self.cdc.read(timeout=None)
+            tmp = received_data
+            while tmp[-7:] != b"</data>" and len(received_data) > 0:
+                received_data = self.cdc.read(timeout=None)
+                tmp += received_data
+            if b'<response' in tmp or b"ERROR" in tmp or len(received_data) == 0:
                 break
             rdata = self.xml.getlog(tmp)[0].replace("0x", "").replace(" ", "")
             tmp2 = b""
@@ -1700,7 +1704,9 @@ class firehose(metaclass=LogBase):
 
         if wf is not None:
             wf.close()
-            if b'<response' in tmp and b'ACK' in tmp:
+            if (b'<response' in tmp and b'ACK' in tmp) or len(received_data) == 0:
+                if len(received_data) == 0:
+                    self.info(f"Warning: {dataread} bytes received, but expecting {SizeInBytes}!")
                 if info:
                     self.info(f"Bytes from {hex(address)}, bytes read {hex(dataread)}, written to {filename}.")
                 return True

--- a/install-linux-edl-drivers.sh
+++ b/install-linux-edl-drivers.sh
@@ -1,13 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-cd ./Drivers
+PATH_DRIVERS=$(dirname "${0}")/Drivers
 
-sudo cp ./50-android.rules /etc/udev/rules.d/50-android.rules
-sudo cp ./51-edl.rules /etc/udev/rules.d/51-edl.rules
-sudo cp ./69-libmtp.rules /etc/udev/rules.d/69-libmtp.rules
-sudo cp ./blacklist-qcserial.conf /etc/modprobe.d/blacklist-qcserial.conf
+[ "$(id -u)" != 0 ] && { printf "You must run this script as root!\n" && exit 1; }
+! [ -d "${PATH_DRIVERS}" ] && { printf "Missing \"Drivers\" directory!\n" && exit 1; }
 
-sudo udevadm control --reload-rules
-sudo udevadm trigger
+cp "${PATH_DRIVERS}"/*.rules /etc/udev/rules.d/
+cp "${PATH_DRIVERS}"/blacklist*.conf /etc/modprobe.d/
 
-echo "Now rebuild your initramfs and reboot."
+udevadm control --reload-rules
+udevadm trigger
+
+printf "Now rebuild your initramfs and reboot\n"


### PR DESCRIPTION
# Improvements

- Added Gentoo (unofficial) support

- Added autoinstall script for Unixes

- Added `pylzma` workaround for `-Wint-conversion` error (GCC >= 14)

- Improved `install-linux-edl-drivers.sh`: now it's POSIX compliant and shell-agnostic

- Improved Firehose `cmd_peek()` error handling (more details below)

- Updated `README.md`

# Extra information
About the `cmd_peek()` improvement, I've made it because this:

```python
Traceback (most recent call last):
  File "/usr/bin/edl", line 4, in <module>
    __import__('pkg_resources').run_script('edlclient==3.62', 'edl')
  File "/usr/lib/python3.12/site-packages/pkg_resources/__init__.py", line 752, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python3.12/site-packages/pkg_resources/__init__.py", line 1739, in run_script
    exec(code, namespace, namespace)
  File "/usr/lib/python3.12/site-packages/edlclient-3.62-py3.12.egg/EGG-INFO/scripts/edl", line 393, in <module>
    base.run()
  File "/usr/lib/python3.12/site-packages/edlclient-3.62-py3.12.egg/EGG-INFO/scripts/edl", line 385, in run
    if not fh.handle_firehose(cmd, options):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/edlclient-3.62-py3.12.egg/edlclient/Library/firehose_client.py", line 397, in handle_firehose
    if self.firehose.cmd_peek(target_name[0][0], target_name[0][1], filename, True):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/edlclient-3.62-py3.12.egg/edlclient/Library/firehose.py", line 1683, in cmd_peek
    rdata = self.xml.getlog(tmp)[0].replace("0x", "").replace(" ", "")
            ~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

happened when I tried to dump the PBL from a `daisy` (`MSM8953`). So on, I've noticed that this is caused by the received Firehose XML packets that were incomplete, so I made `cmd_peek()` to receive data until `</data>` is sent.

Beside this, the `daisy`'s PBL is supposed to send `0x1ffb0` bytes from address `0x100000` (as it uses `MSM8953`), but it actually stops after sending `0x17fb2` bytes. This way, I've also made `cmd_peek()` to actually save the "truncated" data (I'm not sure why this is happening, but this workaround is actually working and the generated file is valid and reverse-engineerable).

Anyways, thanks for such amazing toolkit and related work! It's a truly life saver❣️