### PR TITLE
Update firehose.py for newest X75 Layout

### DIFF
--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -771,7 +771,7 @@ class firehose(metaclass=LogBase):
             self.info("Scanning for partition table ...")
             progbar = progress(1)
             if self.nandpart.partitiontblsector is None:
-                for sector in [0x280,0x400]:
+                for sector in [0x280,0x400,0x800]:
                     progbar.show_progress(prefix="Scanning", pos=sector, total=1024, display=True)
                     resp = self.cmd_read_buffer(0, sector, 1, False)
                     if resp.resp:


### PR DESCRIPTION
RM551E-GL on R02A01 has moved the offset once again, thx @stich86

```
<program PAGES_PER_BLOCK="64" SECTOR_SIZE_IN_BYTES="4096" filename="partition_complete_p4K_b256K.mbn" label="mibib" num_partition_sectors="640" physical_partition_number="0" start_sector="2048"/>
```