### PR TITLE
edl: Handle KeyboardInterrupt for clean exit on Ctrl+C

### DIFF
--- a/edl
+++ b/edl
@@ -406,4 +406,8 @@ class main(metaclass=LogBase):
 
 if __name__ == '__main__':
     base = main(args, __name__)
-    base.run()
+    try:
+        base.run()
+    except KeyboardInterrupt:
+        print("\n[!] Exiting cleanly…")
+        sys.exit(0)


### PR DESCRIPTION
Added a program termination handler for Ctrl+C. Not intended to stop the program during device flashing — used for safely testing the program without a connected device.