### PR TITLE
Add missing script entry point from pyproject.toml

### DIFF
--- a/edl.py
+++ b/edl.py
@@ -405,10 +405,15 @@ class main(metaclass=LogBase):
                     return self.exit(1)
 
 
-if __name__ == '__main__':
+def run():
+    """Script entry point."""
     base = main(args, __name__)
     try:
         base.run()
     except KeyboardInterrupt:
         print("\n[!] Exiting cleanly…")
         sys.exit(0)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
Last week’s d054a7fc introduced a [reference](https://github.com/bkerler/edl/blob/f98e5b279db39fc285a05a72dccdc702edc72d7e/pyproject.toml#L39) to a script entry point `edlclient.edl:run` that doesn’t exist. This causes an error message as user @BeeFox-sys describes it in issue #758.

This PR adds the missing entry point so the `edl` command works.

Fixes #758.
