### PR TITLE
Add Firehose Support for Kaanapali(sm8850) and above

### DIFF
--- a/edlclient/Library/sahara.py
+++ b/edlclient/Library/sahara.py
@@ -20,6 +20,7 @@ from edlclient.Config.qualcomm_config import msmids, root_cert_hash
 from edlclient.Library.loader_db import loader_utils
 from edlclient.Library.sahara_defs import ErrorDesc, cmd_t, exec_cmd_t, sahara_mode_t, status_t, \
     CommandHandler
+from edlclient.Library.xmlparser import xmlparser
 
 
 class sahara(metaclass=LogBase):
@@ -49,6 +50,7 @@ class sahara(metaclass=LogBase):
         self.bit64 = False
         self.pktsize = None
         self.ch = CommandHandler()
+        self.xml = xmlparser()
         self.loader_handler = loader_utils(loglevel=loglevel)
         self.loaderdb = self.loader_handler.init_loader_db()
 
@@ -631,83 +633,115 @@ class sahara(metaclass=LogBase):
     def upload_loader(self, version):
         if self.programmer == "":
             return ""
-        try:
-            self.info(f"Uploading loader {self.programmer} ...")
-            with open(self.programmer, "rb") as rf:
-                programmer = rf.read()
-        except Exception as e:  # pylint: disable=broad-except
-            self.error(str(e))
-            sys.exit()
+
+        is_xml_config = self.programmer.lower().endswith(".xml")
+        mappings = {}
+        
+        if is_xml_config:
+            self.info(f"Parsing Sahara XML config: {self.programmer}")
+            # call xmlparser.py to parse the qsahara_device_programmer.xml
+            mappings = self.xml.parse_sahara_config(self.programmer)
+            if not mappings:
+                self.error("Failed to parse programmer.xml or no images found.")
+                return ""
+        else:
+            try:
+                self.info(f"Uploading loader {self.programmer} ...")  # pylint: disable=broad-except
+                with open(self.programmer, "rb") as rf:
+                    single_programmer_data = rf.read()
+            except Exception as e:  # pylint: disable=broad-except
+                self.error(str(e))
+                sys.exit()
 
         if not self.cmd_hello(sahara_mode_t.SAHARA_MODE_IMAGE_TX_PENDING, version=version):
             return ""
 
         try:
-            datalen = len(programmer)
-            done = False
             loop = 0
-            while datalen >= 0 or done:
+            while True:
                 resp = self.get_rsp()
-                if "cmd" in resp:
-                    cmd = resp["cmd"]
-                else:
-                    cmd = None
-                if cmd == cmd_t.SAHARA_DONE_REQ:
-                    if self.cmd_done():
-                        return self.mode  # Do NOT remove
-                    else:
-                        self.error("Timeout while uploading loader. Wrong loader ?")
-                        return ""
-                elif cmd in [cmd_t.SAHARA_64BIT_MEMORY_READ_DATA, cmd_t.SAHARA_READ_DATA]:
+                if not resp: continue
+                
+                if "firehose" in resp: return "firehose"
+                
+                cmd = resp.get("cmd")
+
+                # handle multiple hello requests (some devices do this for multiple stages of loading)
+                if is_xml_config and cmd == cmd_t.SAHARA_HELLO_REQ:
+                    self.info("Device requested re-handshake (Next stage).")
+                    self.cmd_hello(sahara_mode_t.SAHARA_MODE_IMAGE_TX_PENDING, version=version)
+                    continue
+
+                if cmd in [cmd_t.SAHARA_64BIT_MEMORY_READ_DATA, cmd_t.SAHARA_READ_DATA]:
                     if cmd == cmd_t.SAHARA_64BIT_MEMORY_READ_DATA:
                         self.bit64 = True
-                        if loop == 0:
-                            self.info("64-Bit mode detected.")
-                    elif cmd == cmd_t.SAHARA_READ_DATA:
-                        self.bit64 = False
-                        if loop == 0:
-                            self.info("32-Bit mode detected.")
-                    pkt = resp["data"]
-                    self.id = pkt.image_id
-                    if self.id == 0x7:
-                        self.mode = "nandprg"
-                        if loop == 0:
-                            self.info("NAND mode detected, uploading...")
-                    elif self.id == 0xB:
-                        self.mode = "enandprg"
-                        if loop == 0:
-                            self.info("eNAND mode detected, uploading...")
-                    elif self.id >= 0xC:
-                        self.mode = "firehose"
-                        if loop == 0:
-                            self.info("Firehose mode detected, uploading...")
+                        if loop == 0: self.info("64-Bit mode detected.")
                     else:
-                        self.error(f"Unknown sahara id: {self.id}")
-                        return "error"
+                        self.bit64 = False
+                        if loop == 0: self.info("32-Bit mode detected.")
+                    
+                    pkt = resp["data"]
+                    requested_id = pkt.image_id
+                    
+                    if is_xml_config:
+                        if requested_id in mappings:
+                            file_path = mappings[requested_id]
+                            if requested_id == 0x7: self.mode = "nandprg"
+                            elif requested_id == 0xB: self.mode = "enandprg"
+                            elif requested_id >= 0xC: self.mode = "firehose"
+
+                            with open(file_path, "rb") as rf:
+                                rf.seek(pkt.data_offset)
+                                data_to_send = rf.read(pkt.data_len)
+                                if len(data_to_send) < pkt.data_len:
+                                    data_to_send += b"\xFF" * (pkt.data_len - len(data_to_send))
+                                self.cdc.write(data_to_send)
+                        else:
+                            self.error(f"Device requested unknown ID {requested_id} (not in XML)")
+                            return "error"
+                    else:
+                        self.id = requested_id
+                        if self.id == 0x7: self.mode = "nandprg"
+                        elif self.id == 0xB: self.mode = "enandprg"
+                        elif self.id >= 0xC: self.mode = "firehose"
+
+                        data_offset = pkt.data_offset
+                        data_len = pkt.data_len
+
+                        temp_prog = single_programmer_data
+                        if data_offset + data_len > len(temp_prog):
+                            padding = b"\xFF" * (data_offset + data_len - len(temp_prog))
+                            temp_prog += padding
+                        
+                        data_to_send = temp_prog[data_offset:data_offset + data_len]
+                        self.cdc.write(data_to_send)
+                    
                     loop += 1
-                    data_offset = pkt.data_offset
-                    data_len = pkt.data_len
-                    if data_offset + data_len > len(programmer):
-                        while len(programmer) < data_offset + data_len:
-                            programmer += b"\xFF"
-                    data_to_send = programmer[data_offset:data_offset + data_len]
-                    self.cdc.write(data_to_send)
-                    datalen -= data_len
+
                 elif cmd == cmd_t.SAHARA_END_TRANSFER:
                     pkt = resp["data"]
                     if pkt.image_tx_status == status_t.SAHARA_STATUS_SUCCESS:
                         if self.cmd_done():
-                            self.info("Loader successfully uploaded.")
+                            if not is_xml_config:
+                                self.info("Loader successfully uploaded.")
+                                return self.mode
+                            else:
+                                if requested_id in mappings:
+                                    fname = os.path.basename(mappings[requested_id])
+                                    self.info(f"Stage for ID {requested_id} ({fname}) done.")
+                                else:
+                                    self.info(f"Stage for ID {requested_id} done.")
                         else:
                             self.error("Error on uploading Loader.")
                             sys.exit(1)
-                        return self.mode
                     else:
                         self.error(self.get_error_desc(pkt.image_tx_status))
                         return "error"
-                else:
-                    self.error("Unknown response received on uploading loader.")
-                    sys.exit(1)
+                
+                elif is_xml_config and cmd in [cmd_t.SAHARA_CMD_READY, cmd_t.SAHARA_DONE_RSP]:
+                    self.info("All images from XML uploaded.")
+                    return self.mode if self.mode != "" else "firehose"
+
         except Exception as e:  # pylint: disable=broad-except
             self.error("Unexpected error on uploading, maybe signature of loader wasn't accepted ?\n" + str(e))
             return ""

--- a/edlclient/Library/xmlparser.py
+++ b/edlclient/Library/xmlparser.py
@@ -6,7 +6,7 @@
 # !!!!! If you use this code in commercial products, your product is automatically
 # GPLv3 and has to be open sourced under GPLv3 as well. !!!!!
 import xml.etree.ElementTree as ET
-
+import os
 
 class xmlparser:
     def getresponse(self, input):
@@ -48,3 +48,61 @@ class xmlparser:
                 if 'value' in atype.attrib:
                     data.append(atype.attrib['value'])
         return data
+
+    # add parsing sahara XML config method
+    def parse_sahara_config(self, xml_path):
+
+        mappings = {}
+        
+        if not os.path.exists(xml_path):
+            raise FileNotFoundError(f"Sahara configuration XML not found: {xml_path}")
+
+        try:
+            tree = ET.parse(xml_path)
+            root = tree.getroot()
+            base_dir = os.path.dirname(xml_path)
+
+            if root.tag != "sahara_config":
+                raise Exception("Invalid Sahara config: Root element must be <sahara_config>.")
+
+            chipset_node = root.find("chipset")
+            if chipset_node is not None and chipset_node.text:
+                pass
+
+            images_container = root.find("images")
+            if images_container is None:
+                raise Exception("Invalid Sahara config: Missing <images> container.")
+
+            image_elements = images_container.findall("image")
+            if not image_elements:
+                raise Exception("Invalid Sahara config: No <image> elements found.")
+
+            for img in image_elements:
+                id_str = img.get("image_id")
+                rel_path = img.get("image_path")
+
+                if not id_str or not rel_path:
+                    continue
+
+                try:
+                    img_id = int(id_str)
+                except ValueError:
+                    raise Exception(f"Invalid Sahara config: <image> has a non-numeric image_id '{id_str}'.")
+
+                if img_id in mappings:
+                    raise Exception(f"Invalid Sahara config: Duplicate <image> entry for image_id '{img_id}'.")
+
+                full_path = rel_path if os.path.isabs(rel_path) else os.path.join(base_dir, rel_path)
+
+                if os.path.exists(full_path):
+                    mappings[img_id] = full_path
+                else:
+                    raise FileNotFoundError(f"Sahara image file defined in XML not found: {rel_path} (Full: {full_path})")
+
+            if not mappings:
+                raise Exception("Invalid Sahara config: No valid <image> mappings were produced.")
+            
+            return mappings
+
+        except Exception as e:
+            raise e


### PR DESCRIPTION
Qualcomm has refactored their firehose structure by using qsahara_device_programmer.xml to load a trusted environment before sending the prog_firehose_*.elf
```xml
<?xml version="1.0" ?>
<sahara_config>
	<chipset>molokai</chipset>
	<images>
		<image image_id="36" image_path="multi_image_qti.mbn"/>
		<image image_id="37" image_path="multi_image.mbn"/>
		<image image_id="21" image_path="xbl_sc.elf"/>
		<image image_id="60" image_path="signed_firmware_soc_view.elf"/>
		<image image_id="59" image_path="sequencer_ram.elf"/>
		<image image_id="61" image_path="tme_config.elf"/>
		<image image_id="13" image_path="prog_firehose_ddr.elf"/>
		<image image_id="38" image_path="xbl_config_devprg.elf"/>
	</images>
</sahara_config>
```

So ive commited a code here to support this change, here is the result tested on sm8845 (same on sm8850 and above)

<img width="848" height="639" alt="image" src="https://github.com/user-attachments/assets/3d904b35-ea3b-4a73-84f7-94004005e9c2" />

```
 littlenine@Littlenines-MacBook-Air  ~/Desktop/QRD8650/edl   master  python edl.py printgpt --memory=ufs --loader qsahara_device_programmer.xml
Keystone library is missing (optional).
Qualcomm Sahara / Firehose Client V3.62 (c) B.Kerler 2018-2025.
main - Using loader qsahara_device_programmer.xml ...
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 3, Version supported: 1
main - Mode detected: sahara
sahara - 
Reading Chip Info : OK
sahara - - Sahara version  : 3
sahara - - Chip Serial Number : 47bda895388
sahara - - Chip Identifier V3 : 00020001
sahara - - MSM HWID : 0x2fd0e1 | model_id:0x0000 | oem_id:0001
sahara - - OEM PKHASH : 00000000
sahara - - HW_ID : 002fd0e100010000
sahara - Protocol version: 3, Version supported: 1
sahara - Parsing Sahara XML config: qsahara_device_programmer.xml
sahara - 64-Bit mode detected.
sahara - Stage for ID 59 (sequencer_ram.elf) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 36 (multi_image_qti.mbn) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 37 (multi_image.mbn) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 61 (tme_config.elf) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 60 (signed_firmware_soc_view.elf) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 21 (xbl_sc.elf) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 13 (prog_firehose_ddr.elf) done.
sahara - Device requested re-handshake (Next stage).
sahara - Stage for ID 38 (xbl_config_devprg.elf) done.
main - Trying to connect to firehose loader ...
firehose - INFO: Binary build date: Feb 26 2026 @ 09:47:33 
firehose - INFO: Chip serial num (0xda895388) Chip ID (0x47b)
firehose - INFO: Supported Functions (15):
firehose - INFO: program
firehose - INFO: read
firehose - INFO: nop
firehose - INFO: patch
firehose - INFO: configure
firehose - INFO: setbootablestoragedrive
firehose - INFO: erase
firehose - INFO: power
firehose - INFO: firmwarewrite
firehose - INFO: getstorageinfo
firehose - INFO: benchmark
firehose - INFO: emmc
firehose - INFO: ufs
firehose - INFO: fixgpt
firehose - INFO: getsha256digest
firehose - INFO: End of supported functions 15
firehose
firehose - [LIB]: Couldn't detect MaxPayloadSizeFromTargetinBytes
firehose
firehose - [LIB]: Couldn't detect TargetName
firehose - TargetName=Unknown
firehose - MemoryName=UFS
firehose - Version=1
firehose - Trying to read first storage sector...
firehose - Running configure...
firehose - Storage report:
firehose - total_blocks:59293696
firehose - block_size:4096
firehose - page_size:4096
firehose - num_physical:8
firehose - spec_version:410
firehose - manufacturer_id:462
firehose - serial_num:1297306958
firehose - fw_version:500
firehose - mem_type:UFS
firehose - prod_name:KLUEG4RHHF-F0G1
firehose_client - Supported functions:
-----------------
program,read,nop,patch,configure,setbootablestoragedrive,erase,power,firmwarewrite,getstorageinfo,benchmark,emmc,ufs,fixgpt,getsha256digest
```

Also tested on normal platform (mine is sm8650) and it has no impact on the old process

<img width="860" height="456" alt="image" src="https://github.com/user-attachments/assets/bd096d66-0589-4ec7-a344-233715c1207c" />

```
 littlenine@Littlenines-MacBook-Air  ~/Desktop/QRD8650/edl   master ±  python edl.py printgpt --memory=ufs --loader xbl_s_devprg_ns.melf                             
Keystone library is missing (optional).
Qualcomm Sahara / Firehose Client V3.62 (c) B.Kerler 2018-2025.
main - Using loader xbl_s_devprg_ns.melf ...
main - Waiting for the device
main - Device detected :)
sahara - Protocol version: 3, Version supported: 1
main - Mode detected: sahara
sahara - 
Reading Chip Info : OK
sahara - - Sahara version  : 3
sahara - - Chip Serial Number : 44865683f70
sahara - - Chip Identifier V3 : 00020000
sahara - - MSM HWID : 0x2270e1 | model_id:0x0000 | oem_id:0000
sahara - - OEM PKHASH : 00000000
sahara - - HW_ID : 002270e100000000
sahara - Protocol version: 3, Version supported: 1
sahara - Uploading loader xbl_s_devprg_ns.melf ...
sahara - 64-Bit mode detected.
sahara - Loader successfully uploaded.
main - Trying to connect to firehose loader ...
firehose - INFO: Binary build date: Nov 12 2025 @ 12:22:43
firehose - INFO: Binary build date: Nov 12 2025 @ 12:22:43 
firehose - INFO: Chip serial num (0x0) Chip ID (0x0)
firehose - INFO: Supported Functions (15):
firehose - INFO: program
firehose - INFO: read
firehose - INFO: nop
firehose - INFO: patch
firehose - INFO: configure
firehose - INFO: setbootablestoragedrive
firehose - INFO: erase
firehose - INFO: power
firehose - INFO: firmwarewrite
firehose - INFO: getstorageinfo
firehose - INFO: benchmark
firehose - INFO: emmc
firehose - INFO: ufs
firehose - INFO: fixgpt
firehose - INFO: getsha256digest
firehose - INFO: End of supported functions 15
firehose
firehose - [LIB]: Couldn't detect MaxPayloadSizeFromTargetinBytes
firehose
firehose - [LIB]: Couldn't detect TargetName
firehose - TargetName=Unknown
firehose - MemoryName=UFS
firehose - Version=1
firehose - Trying to read first storage sector...
firehose - Running configure...
firehose - Storage report:
firehose - total_blocks:59293696
firehose - block_size:4096
firehose - page_size:4096
firehose - num_physical:8
firehose - manufacturer_id:408
firehose - serial_num:1481195808
firehose - fw_version:300
firehose - mem_type:UFS
firehose - prod_name:THGJFJT1E45BATPC0300
firehose_client - Supported functions:
-----------------
program,read,nop,patch,configure,setbootablestoragedrive,erase,power,firmwarewrite,getstorageinfo,benchmark,emmc,ufs,fixgpt,getsha256digest
```
The similar commit ive done has been merged on another tool
https://github.com/strongtz/edl-ng/commit/eb8a061a999c0979c62c46eaf5e0a07dd1aa53dd

Best Regards,
Littlenine