### PR TITLE
Improve Windows libusb backend detection

### DIFF
--- a/edlclient/Library/Connection/usblib.py
+++ b/edlclient/Library/Connection/usblib.py
@@ -15,13 +15,12 @@ from enum import Enum
 import usb.backend.libusb0
 import usb.core  # pyusb
 import usb.util
+import usb.backend.libusb1
 
 try:
     from edlclient.Library.utils import *
 except:
     from Library.utils import *
-if not is_windows():
-    import usb.backend.libusb1
 from struct import pack
 
 try:
@@ -78,7 +77,14 @@ class usb_class(DeviceClass):
         if sys.platform.startswith('freebsd') or sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
             self.backend = usb.backend.libusb1.get_backend(find_library=lambda x: "libusb-1.0.so")
         elif is_windows():
-            self.backend = None
+            dll = os.path.join(
+                os.path.abspath(os.path.dirname(__file__)),
+                "..", "..", "Windows", "libusb-1.0.dll"
+            )
+
+            self.backend = usb.backend.libusb1.get_backend(
+                find_library=lambda x: dll
+            )
         if self.backend is not None:
             try:
                 self.backend.lib.libusb_set_option.argtypes = [c_void_p, c_int]


### PR DESCRIPTION
## Summary

This change explicitly initializes the bundled `libusb-1.0.dll` when running on Windows.

On my Windows 10 system, PyUSB was unable to automatically locate the bundled library, preventing communication with Qualcomm EDL devices.

By explicitly passing the bundled DLL to `usb.backend.libusb1.get_backend()`, communication with the device was successfully established.

## Tested configuration

- Windows 10
- Python 3.11
- Nokia 6300 4G (Qualcomm MSM8909)

Successfully verified:

- Sahara handshake
- Firehose loader upload
- GPT parsing
- Partition enumeration
- Partition read
- Partition write

## Notes

This change has currently been tested on the configuration above and is intended to improve Windows compatibility where the bundled `libusb-1.0.dll` is not automatically detected.