### PR TITLE
Fix qfil firehose request/response bugs (issues #808, #809, #810)

### DIFF
--- a/edlclient/Library/Connection/devicehandler.py
+++ b/edlclient/Library/Connection/devicehandler.py
@@ -41,6 +41,7 @@ class DeviceClass(metaclass=LogBase):
         self.__logger.setLevel(loglevel)
         if loglevel == logging.DEBUG:
             logfilename = os.path.join("logs", "log.txt")
+            os.makedirs(os.path.dirname(logfilename), exist_ok=True)
             fh = logging.FileHandler(logfilename, encoding='utf-8')
             self.__logger.addHandler(fh)
 

--- a/edlclient/Library/Connection/seriallib.py
+++ b/edlclient/Library/Connection/seriallib.py
@@ -155,7 +155,14 @@ class serial_class(DeviceClass):
         return self.usbread(length, timeout)
 
     def flush(self):
-        return self.device.flush()
+        # flush() only drains the *write* buffer. Callers use this to discard a
+        # stale reply before sending a new command, so the input buffer has to be
+        # reset as well, otherwise every later read is one reply behind.
+        self.device.flush()
+        pending = self.device.in_waiting
+        if pending:
+            self.debug(f"Flushed {pending} stale bytes from the read buffer")
+            self.device.reset_input_buffer()
 
     def usbread(self, resplen=None, timeout=0):
         if resplen is None:

--- a/edlclient/Library/Connection/usblib.py
+++ b/edlclient/Library/Connection/usblib.py
@@ -208,7 +208,23 @@ class usb_class(DeviceClass):
         self.debug("Linecoding set, {}b sent".format(wlen))
 
     def flush(self):
-        return
+        # Drain anything the device left in the bulk-in endpoint. A no-op flush
+        # let an unread reply survive into the next command, so every following
+        # transfer read the *previous* command's response (one-reply-behind
+        # desync) with no way to ever resynchronise.
+        if not self.connected or self.EP_IN is None:
+            return
+        discarded = 0
+        while discarded < MAX_USB_BULK_BUFFER_SIZE:
+            try:
+                rlen = self.EP_IN.read(self.buffer, 1)
+            except usb.core.USBError:
+                break
+            if not rlen:
+                break
+            discarded += rlen
+        if discarded:
+            self.debug(f"Flushed {discarded} stale bytes from the read buffer")
 
     def connect(self, EP_IN=-1, EP_OUT=-1, portname: str = ""):
         if self.connected:

--- a/edlclient/Library/firehose.py
+++ b/edlclient/Library/firehose.py
@@ -272,7 +272,7 @@ class firehose(metaclass=LogBase):
             while b"<response value" not in rdata:
                 try:
                     tmp = self.cdc.read(timeout=None)
-                    if tmp == b"" in rdata:
+                    if tmp == b"":
                         counter += 1
                         time.sleep(0.05)
                         if counter > timeout:
@@ -281,6 +281,13 @@ class firehose(metaclass=LogBase):
                 except Exception as err:
                     self.error(err)
                     return response(resp=False, error=str(err))
+            if b"<response value" not in rdata:
+                # The loop above gave up. getstatus() reports an empty/unparsed
+                # reply as ACK, so without this a timed-out command looks like a
+                # successful one.
+                err = "Timed out waiting for a response from the device"
+                self.error(err)
+                return response(resp=False, error=err, data=rdata)
             try:
                 if b"raw hex token" in rdata:
                     rdata = rdata
@@ -295,6 +302,15 @@ class firehose(metaclass=LogBase):
                             else:
                                 error = self.xml.getlog(rdata)
                                 return response(resp=status, error=error, data=resp, log=error)
+                        else:
+                            # rawmode="true": the device is now waiting for the
+                            # payload. Return the parsed attributes so callers can
+                            # tell an ACK from a NAK; falling through to the generic
+                            # handler below used to work only by accident.
+                            if status:
+                                return response(resp=True, data=resp)
+                            error = self.xml.getlog(rdata)
+                            return response(resp=False, error=error, data=resp, log=error)
                     else:
                         if status:
                             if b"log value=" in rdata:
@@ -531,6 +547,10 @@ class firehose(metaclass=LogBase):
                 else:
                     self.error(f"Error:{rsp}")
                     return False
+            else:
+                self.error(f"Error: device rejected the program command for "
+                           f"{filename}: {rsp.error}")
+                return False
         return True
 
     def cmd_program_buffer(self, physical_partition_number, start_sector, wfdata, display=True):
@@ -590,6 +610,7 @@ class firehose(metaclass=LogBase):
                 return False
         else:
             self.error(f"Error:{rsp.error}")
+            return False
         return True
 
     def cmd_erase(self, physical_partition_number, start_sector, num_partition_sectors, display=True):
@@ -712,7 +733,9 @@ class firehose(metaclass=LogBase):
                     return False
             else:
                 if display:
-                    self.error(f"Error:{rsp[2]}")
+                    error = info if info else ["Missing or unparseable response from the device"]
+                    for line in error:
+                        self.error(line)
                     return False
         return True
 
@@ -733,7 +756,7 @@ class firehose(metaclass=LogBase):
 
         progbar = progress(self.cfg.SECTOR_SIZE_IN_BYTES)
         rsp = self.xmlsend(data, self.skipresponse)
-        if "value" in rsp.data and rsp.data["value"] == "NAK":
+        if isinstance(rsp.data, dict) and rsp.data.get("value") == "NAK":
             return rsp
         self.cdc.xmlread = False
         resData = bytearray()
@@ -766,25 +789,34 @@ class firehose(metaclass=LogBase):
                     if rsp["rawmode"] == "false":
                         return response(resp=True, data=resData)
             else:
-                if len(rsp) > 1:
-                    if b"Failed to open the UFS Device" in rsp[2]:
-                        self.error(f"Error:{rsp[2]}")
-                    self.lasterror = rsp[2]
-                return response(resp=False, data=resData, error=rsp[2])
-        if rsp["value"] != "ACK":
-            self.lasterror = rsp[2]
+                # rsp is the parsed attribute dict, so the old rsp[2] indexing
+                # always raised KeyError here and aborted the read instead of
+                # reporting it. The device log is the only error detail we have.
+                error = info if info else ["Missing or unparseable response from the device"]
+                for line in error:
+                    if "Failed to open the UFS Device" in line:
+                        self.error(f"Error:{line}")
+                self.lasterror = b"".join(bytes(line + "\n", "utf-8") for line in error)
+                return response(resp=False, data=resData, error=error)
         if display and prog != 100:
             progbar.show_progress(prefix="Read", pos=total, total=total, display=display)
-        resp = rsp["value"] == "ACK"
-        return response(resp=resp, data=resData, error=rsp[2])  # Do not remove, needed for oneplus
+        resp = rsp.get("value") == "ACK"
+        error = [] if resp else (info if info else ["Unexpected response: " + str(rsp)])
+        if not resp:
+            self.lasterror = b"".join(bytes(line + "\n", "utf-8") for line in error)
+        return response(resp=resp, data=resData, error=error)  # Do not remove, needed for oneplus
 
     def get_gpt(self, lun, gpt_num_part_entries, gpt_part_entry_size, gpt_part_entry_start_lba, start_sector=1):
         try:
             resp = self.cmd_read_buffer(lun, 0, 1, False)
         except Exception as err:
             self.debug(str(err))
+            oldskip = self.skipresponse
             self.skipresponse = True
-            resp = self.cmd_read_buffer(lun, 0, 1, False)
+            try:
+                resp = self.cmd_read_buffer(lun, 0, 1, False)
+            finally:
+                self.skipresponse = oldskip
 
         if not resp.resp:
             for line in resp.error:

--- a/edlclient/Library/firehose_client.py
+++ b/edlclient/Library/firehose_client.py
@@ -951,6 +951,13 @@ class firehose_client(metaclass=LogBase):
                                 num_disk_sectors = self.firehose.getlunsize(partition_number)
                                 start_sector = elem.get("start_sector")
                                 if "NUM_DISK_SECTORS" in start_sector:
+                                    if num_disk_sectors <= 0:
+                                        self.error(f"Could not determine size of LUN "
+                                                   f"{partition_number} (getlunsize returned "
+                                                   f"{num_disk_sectors}). Refusing to write "
+                                                   f"{filename} at a bogus offset.")
+                                        success = False
+                                        continue
                                     start_sector = start_sector.replace("NUM_DISK_SECTORS", str(num_disk_sectors))
                                 if "-" in start_sector or "*" in start_sector or "/" in start_sector or \
                                         "+" in start_sector:
@@ -959,7 +966,12 @@ class firehose_client(metaclass=LogBase):
                                 self.info(f"[qfil] programming {filename} to partition({partition_number})" +
                                           f"@sector({start_sector})...")
 
-                                self.firehose.cmd_program(int(partition_number), int(start_sector), filename)
+                                if not self.firehose.cmd_program(int(partition_number),
+                                                                 int(start_sector), filename):
+                                    self.error(f"Failed to program {filename} to "
+                                               f"partition({partition_number})"
+                                               f"@sector({start_sector})")
+                                    success = False
                 else:
                     self.warning(f"File : {filename} not found.")
                     success = False
@@ -984,7 +996,6 @@ class firehose_client(metaclass=LogBase):
                             content = ElementTree.tostring(elem).decode("utf-8")
                             CMD = "<?xml version=\"1.0\" ?><data>\n {content} </data>".format(
                                 content=content)
-                            print(CMD)
                             self.firehose.xmlsend(CMD)
                 else:
                     self.warning(f"File : {filename} not found.")

--- a/edlclient/Library/gpt.py
+++ b/edlclient/Library/gpt.py
@@ -94,6 +94,7 @@ def logsetup(self, logger, loglevel):
     self.warning = logger.warning
     if loglevel == logging.DEBUG:
         logfilename = os.path.join("logs", "log.txt")
+        os.makedirs(os.path.dirname(logfilename), exist_ok=True)
         if os.path.exists(logfilename):
             try:
                 os.remove(logfilename)


### PR DESCRIPTION
## Summary
Fixes USB/serial “one-reply-behind” desyncs, hardens xml/firehose response handling and error reporting, and ensures log directories exist.

## What changed
- Implement input-buffer draining in serial and USB `flush()` implementations to discard stale/readable bytes and avoid desynchronization.
- Improve `xmlsend` and firehose response handling:
  - Correct timeout/empty-read detection and return explicit error responses on timeouts.
  - Distinguish ACK/NAK and `rawmode` responses correctly so callers can react to failures.
  - Replace fragile indexing of parsed responses with safe dict checks and safer `lasterror` construction.
  - Ensure functions return `False` on error paths where they previously fell through.
  - Preserve `skipresponse` state across retry attempts.
- Add defensive checks in `firehose_client` to validate LUN/disk sizes before writing and to surface `cmd_program` failures.
- Ensure logging setup creates the parent `logs` directory before creating/removing log files.
- Remove a stray debug `print`.

## Files touched
- `edlclient/Library/Connection/devicehandler.py`
- `edlclient/Library/Connection/seriallib.py`
- `edlclient/Library/Connection/usblib.py`
- `edlclient/Library/firehose.py`
- `edlclient/Library/firehose_client.py`
- `edlclient/Library/gpt.py`

## Why
- `device.flush()` previously only drained the write buffer; unread replies could survive into the next command, causing every later read to be one reply behind. Draining the input/endpoint read buffer prevents this desync.
- Timeouts and unparseable device responses were sometimes treated as successes or caused `KeyError` crashes; explicit error returns and safer parsing make failures visible and actionable.
- Protects against accidental writes using bogus LUN/sector sizes and surfaces programming failures so callers know when operations fail.
- Prevents `FileHandler` failures when the logs directory does not exist.

## Testing recommendations
- Run device integration tests for serial and USB transports, exercising:
  - Commands that time out (verify `xmlsend` returns `resp=False` with an error message).
  - Sequences that previously caused “one-reply-behind” to confirm proper synchronization.
  - Programming flows that use `NUM_DISK_SECTORS` edge cases.
- Validate behavior on target platforms/devices (ensure `reset_input_buffer`, `in_waiting`, `self.buffer`, and `MAX_USB_BULK_BUFFER_SIZE` behave as expected).
- Run unit tests around firehose parsing branches and error paths.

## Risk and compatibility
- Low-risk internal robustness fixes. No public API changes intended.
- Reviewers should confirm callers do not rely on old tuple/list indexing of response objects; this change standardizes on dict access in places where parsed responses are used.

## Notes for reviewers
- Verify serial backend methods used (`in_waiting`, `reset_input_buffer`) exist and are safe on supported device objects.
- Check the USB drain loop bounds and that `self.buffer` / `MAX_USB_BULK_BUFFER_SIZE` are defined and appropriate on all platforms.
- Confirm there are no remaining code paths that assume `rsp` is indexable by integer (e.g., `rsp[2]`) without safe guards.
